### PR TITLE
change delete account text for edly

### DIFF
--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -73,7 +73,7 @@ export class StudentAccountDeletion extends React.Component {
     );
 
     const acctDeletionWarningText = StringUtils.interpolate(
-      gettext('{strongStart}Warning: Account deletion is permanent.{strongEnd} Please read the above carefully before proceeding. This is an irreversible action, and {strongStart}you will no longer be able to use the same email on edX.{strongEnd}'),
+      gettext('{strongStart}Warning: Account deletion is permanent.{strongEnd} Please read the above carefully before proceeding. This is an irreversible action, and {strongStart}you will no longer be able to use the same email on Edly.{strongEnd}'),
       {
         strongStart: '<strong>',
         strongEnd: '</strong>',
@@ -83,8 +83,8 @@ export class StudentAccountDeletion extends React.Component {
     return (
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+        <p className="account-settings-header-subtitle">{ gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. We will not be able to recover your account or the data that is deleted.') }</p>
+        <p className="account-settings-header-subtitle">{ gettext('Once your account is deleted, you cannot use it to take courses on the Edly app, edly.io, or any other site hosted by Edly.') }</p>
         <p
           className="account-settings-header-subtitle"
           dangerouslySetInnerHTML={{ __html: loseAccessText }}

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -137,8 +137,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                       <Icon id="delete-confirmation-body-warning-icon" className={['fa', 'fa-exclamation-triangle']} />
                     </div>
                     <div className="alert-content">
-                      <h3 className="alert-title">{ gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</h3>
-                      <p>{ gettext('If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+                      <h3 className="alert-title">{ gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. Edly will not be able to recover your account or the data that is deleted.') }</h3>
+                      <p>{ gettext('If you proceed, you cannot use it to take courses on the Edly app or any other site hosted by Edly.') }</p>
                       <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -300,7 +300,7 @@
             // Add the social link fields
             socialFields = {
                 title: gettext('Social Media Links'),
-                subtitle: gettext('Optionally, link your personal accounts to the social media icons on your edX profile.'),  // eslint-disable-line max-len
+                subtitle: gettext('Optionally, link your personal accounts to the social media icons on your Edly profile.'),  // eslint-disable-line max-len
                 fields: []
             };
 


### PR DESCRIPTION
Replace the default delete account text for `Edly`

**Account deletion section (before):**
<img width="1309" alt="Screen Shot 2019-08-02 at 11 51 28 AM" src="https://user-images.githubusercontent.com/5072991/62351680-acd89700-b51f-11e9-8f22-13e349b6f2b3.png">
<img width="680" alt="Screen Shot 2019-08-02 at 11 57 07 AM" src="https://user-images.githubusercontent.com/5072991/62351691-b530d200-b51f-11e9-9975-fc39f2d34d92.png">


**Account deletion section (after):**
<img width="1276" alt="Screen Shot 2019-08-02 at 12 15 46 PM" src="https://user-images.githubusercontent.com/5072991/62351699-be21a380-b51f-11e9-9e92-8165a8ae6f77.png">
<img width="1142" alt="Screen Shot 2019-08-02 at 12 15 59 PM" src="https://user-images.githubusercontent.com/5072991/62351717-c548b180-b51f-11e9-98be-f7a3a1142b79.png">

**Social Media Links (before):**
<img width="1287" alt="Screen Shot 2019-08-02 at 12 15 28 PM" src="https://user-images.githubusercontent.com/5072991/62351747-dabddb80-b51f-11e9-86a6-595ad7af5ec0.png">


**Social Media Links (after):**
<img width="916" alt="Screen Shot 2019-08-02 at 12 16 34 PM" src="https://user-images.githubusercontent.com/5072991/62351757-dee9f900-b51f-11e9-8f11-228b5354260b.png">
