### PR TITLE
FIX: fix session cookies deletion

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1320,6 +1320,7 @@ MIDDLEWARE_CLASSES = [
 
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 
+    'openedx.features.edly.middleware.SessionCookieMiddleware',
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]

--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -1,0 +1,14 @@
+
+from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
+
+
+class SessionCookieMiddleware(object):
+    """
+    Deletes the login session cookies if user is not authenticated
+    """
+
+    def process_response(self, request, response):
+        if not request.user.is_authenticated:
+            delete_logged_in_cookies(response)
+
+        return response

--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -8,7 +8,7 @@ class SessionCookieMiddleware(object):
     """
 
     def process_response(self, request, response):
-        if not request.user.is_authenticated:
+        if hasattr(request, 'user') and not request.user.is_authenticated:
             delete_logged_in_cookies(response)
 
         return response


### PR DESCRIPTION
This change is required to handle the scenario in which the cookies are maintained in the browser even though the user session has expired on the back-end.

I tried to solve this using the [SESSION_COOKIE_AGE](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SESSION_COOKIE_AGE) setting. That is a default django framework setting that decides the total time a session cookie should be active in the user's browser. However, that solution did not work in our case.

As a last resort, I have added this middleware which deletes the logged in cookies in a user's browser if a request from an anonymous user comes. 

Without this middleware, the session cookies are deleted only if the user explicitly logs out of the platform. If the user, let's the browser sit idle for 24-48 hours then the session will expire on the backend but the cookies will remain in the browser. This creates the illusion that the user is logged in while he isn't.

![image](https://user-images.githubusercontent.com/14261053/63211430-4bfcb180-c110-11e9-80d8-0fe9e50e3f10.png)
User is logged out in Open edX


![image](https://user-images.githubusercontent.com/14261053/63211436-646ccc00-c110-11e9-80c4-23ec263eb33b.png)
User is shown as logged-in on WordPress

Our custom middleware is written as a separate django app and is included in the request/response life cycle. If an alternative to this approach is found that does not require changes in the core Open edX code, then that solution should be adopted and this should be reverted.

