### PR TITLE
Add EdlyStudentAccountDeletionInitializer entry point for themes

### DIFF
--- a/lms/static/lms/js/build.js
+++ b/lms/static/lms/js/build.js
@@ -34,6 +34,7 @@
             'js/header_factory',
             'js/student_account/logistration_factory',
             'js/student_account/views/account_settings_factory',
+            'st-lutherx/js/student_account/views/edly_account_settings_factory',
             'js/student_account/views/finish_auth_factory',
             'js/views/message_banner',
             'learner_profile/js/learner_profile_factory',

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -91,6 +91,7 @@ module.exports = Merge.smart({
             PasswordResetConfirmation: './lms/static/js/student_account/components/PasswordResetConfirmation.jsx',
             StudentAccountDeletion: './lms/static/js/student_account/components/StudentAccountDeletion.jsx',
             StudentAccountDeletionInitializer: './lms/static/js/student_account/StudentAccountDeletionInitializer.js',
+            EdlyStudentAccountDeletionInitializer: './themes/st-lutherx/lms/static/js/student_account/StudentAccountDeletionInitializer.js',
             ProblemBrowser: './lms/djangoapps/instructor/static/instructor/ProblemBrowser/index.jsx',
 
             // Learner Dashboard


### PR DESCRIPTION
Add `EdlyStudentAccountDeletionInitializer` entry point for edly theme `st-lutherx`.

**Related PR:** https://github.com/edly-io/edly-edx-themes/pull/91/files