### PR TITLE
use EdlyStudentAccountDeletionInitializer from lums theme

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -91,7 +91,7 @@ module.exports = Merge.smart({
             PasswordResetConfirmation: './lms/static/js/student_account/components/PasswordResetConfirmation.jsx',
             StudentAccountDeletion: './lms/static/js/student_account/components/StudentAccountDeletion.jsx',
             StudentAccountDeletionInitializer: './lms/static/js/student_account/StudentAccountDeletionInitializer.js',
-            EdlyStudentAccountDeletionInitializer: './themes/st-lutherx/lms/static/js/student_account/StudentAccountDeletionInitializer.js',
+            EdlyStudentAccountDeletionInitializer: './themes/lums/lms/static/js/student_account/StudentAccountDeletionInitializer.js',
             ProblemBrowser: './lms/djangoapps/instructor/static/instructor/ProblemBrowser/index.jsx',
 
             // Learner Dashboard


### PR DESCRIPTION
Use `EdlyStudentAccountDeletionInitializer` from `lums` theme.

We will use this `lums` branch for deploying the `edx-platform` for Lums instance.