### PR TITLE
add pdf xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,6 +37,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+-e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -40,6 +40,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+-e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
 -e common/lib/xmodule
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -102,3 +102,4 @@
 -e git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 -e git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+-e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -38,6 +38,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+-e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.2.9


### PR DESCRIPTION
Add pdf xbloc (https://github.com/raccoongang/xblock-pdf).

**There were other outdated pdf xblocks:**

1. https://github.com/polimediaupv/pdfXBlock
2. https://github.com/MarCnu/pdfXBlock

**Openedx Xblocks Directory:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/43385346/XBlocks+Directory

**Testing Instructions:**

1. Add `pdf` in the course `Advanced Settings`
<img width="1389" alt="Screen Shot 2019-10-17 at 4 59 21 PM" src="https://user-images.githubusercontent.com/5072991/67007096-18360c00-f100-11e9-9dcb-ca428447b9b1.png">

2. Go to a course `unit` and add the `pdf` component from the `Advanced` module types
<img width="1389" alt="Screen Shot 2019-10-17 at 4 59 40 PM" src="https://user-images.githubusercontent.com/5072991/67007112-208e4700-f100-11e9-943e-0d34b53db891.png">

3. Publish the `pdf` component after updating the pdf link
<img width="1388" alt="Screen Shot 2019-10-17 at 5 00 35 PM" src="https://user-images.githubusercontent.com/5072991/67007132-2c7a0900-f100-11e9-905d-92b0d3fc5c5d.png">

4. Verify that the users can now view the pdf within openedx courseware
<img width="1387" alt="Screen Shot 2019-10-17 at 5 05 41 PM" src="https://user-images.githubusercontent.com/5072991/67007238-5fbc9800-f100-11e9-8c02-fbceca563859.png">
