### PR TITLE
update discussion settings for lums

### DIFF
--- a/lms/djangoapps/discussion/settings/common.py
+++ b/lms/djangoapps/discussion/settings/common.py
@@ -6,5 +6,9 @@ def plugin_settings(settings):
     settings.FEATURES['ALLOW_HIDING_DISCUSSION_TAB'] = False
     settings.DISCUSSION_SETTINGS = {
         'MAX_COMMENT_DEPTH': 2,
+        'MAX_UPLOAD_FILE_SIZE': 5 * 1024 * 1024,  # result in bytes
+        'ALLOWED_UPLOAD_FILE_TYPES': (
+            '.jpg', '.jpeg', '.gif', '.bmp', '.png', '.tiff', '.pdf', '.doc', '.docx',
+        ),
         'COURSE_PUBLISH_TASK_DELAY': 30,
     }


### PR DESCRIPTION
Update discussion settings for `lums`.

`MAX_COMMENT_DEPTH` = 2
`MAX_UPLOAD_FILE_SIZE` = 5 MB
`ALLOWED_UPLOAD_FILE_TYPES` = `['.jpg', '.jpeg', '.gif', '.bmp', '.png', '.tiff', '.pdf', '.doc', '.docx']`