### PR TITLE
upgrade social-auth-core to 3.2.0 to fix authorization with linkedin

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -132,7 +132,7 @@ reportlab                           # Used for shopping cart's pdf invoice/recei
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django<3.0.0
-social-auth-core<2.0.0
+social-auth-core==3.2.0
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -226,7 +226,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 soupsieve==1.7.1          # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -311,7 +311,7 @@ slumber==0.7.1
 snakefood==1.4
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 soupsieve==1.7.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -298,7 +298,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 soupsieve==1.7.1


### PR DESCRIPTION
Upgrade `social-auth-core` version from `1.7.0` to `3.2.0` to fix authorization with `Linkedin`.