### PR TITLE
Disbale OK Button untill some file is selected

### DIFF
--- a/lms/static/js/Markdown.Editor.js
+++ b/lms/static/js/Markdown.Editor.js
@@ -1130,14 +1130,41 @@
             cancelButton.onclick = function() { return close(true); };
 
             if (imageUploadHandler) {
+              var descriptionFieldHasContent,
+                valueOfUrlField,
+                urlFieldHasContent,
+                uploadFieldHasContent,
+                urlAndDescriptionFieldHasContent,
+                imageAndDescriptionFieldHasContent;
+                okButton.disabled = true;
                 var startUploadHandler = function() {
-                    document.getElementById('file-upload').onchange = function() {
+                    document.getElementById('file-upload').onchange = function(event) {
                         imageUploadHandler(this, urlInput);
                         urlInput.focus();
 
+                        descriptionFieldHasContent = $.trim(descInput.value).length;
+                        okButton.disabled = !(descriptionFieldHasContent && event.target.value.length);
                         // Ensures that a user can update their file choice.
                         startUploadHandler();
                     };
+
+                    urlInput.oninput = toggleSubmitButton;
+
+                    descInput.oninput = toggleSubmitButton;
+
+                    function toggleSubmitButton() {
+                      okButton.disabled=true;
+                      descriptionFieldHasContent = $.trim(descInput.value).length;
+                      valueOfUrlField = $.trim(urlInput.value);
+                      urlFieldHasContent = valueOfUrlField.replace(/^https?:\/\//i, '').length;
+                      uploadFieldHasContent = document.getElementById('file-upload').value.length;
+                      imageAndDescriptionFieldHasContent = (descriptionFieldHasContent && uploadFieldHasContent);
+                      urlAndDescriptionFieldHasContent = (descriptionFieldHasContent && urlFieldHasContent);
+
+                      if (imageAndDescriptionFieldHasContent || urlAndDescriptionFieldHasContent) {
+                        okButton.disabled = false;
+                      }
+                    }
                 };
                 startUploadHandler();
                 document.getElementById('file-upload-proxy').onclick = function() {


### PR DESCRIPTION
#### This PR contains the work related to the ticket

- By default, the ok button of file upload dialog is clickable whether the URL/file is selected/written now it will be disabled until user selects some file or enter some URL.