### PR TITLE
FIX: Comment not submitted on post

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -220,7 +220,18 @@
 
             request = $.ajax(params).always(function() {
                 if ($elem) {
-                    $elem.prop('disabled', false);
+                    // We don't want to enable the "submit" buttons for post or comment here.
+                    // The buttons will be enabled once there is some text entered.
+                    var elemClassList = $elem.context && $elem.context.classList;
+                    if(
+                        !elemClassList ||
+                        !(
+                            elemClassList.contains('discussion-submit-post') ||
+                            elemClassList.contains('discussion-submit-comment')
+                        )
+                    ){
+                        $elem.prop('disabled', false);
+                    }
                 }
                 if (params.$loading) {
                     if (params.loadedCallback) {

--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -378,7 +378,6 @@
                 });
                 this.model.addComment();
                 this.renderAddResponseButton();
-                event.target.disabled = true
                 return DiscussionUtil.safeAjax({
                     $elem: $(event.target),
                     url: url,

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -209,7 +209,6 @@
                 view = this.renderComment(comment);
                 this.hideEditorChrome();
                 this.trigger('comment:add', comment);
-                event.target.disabled = true;
                 return DiscussionUtil.safeAjax({
                     $elem: $(event.target),
                     url: url,


### PR DESCRIPTION
### BUG: 
When we disable the buttons before the ajax call, the `safeAjax` method validates if the element is not disabled (in our case, it is) and hence doesn't perform the ajax request and doesn't get submitted to the server.

### Solution:
Keep the button disabled after the ajax call and enable only when there is some text entered.