### PR TITLE
Fix export_olx command issue

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/export_olx.py
@@ -91,9 +91,7 @@ def export_course_to_directory(course_key, root_dir):
     # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
     # We represent the first four with \w.
     # TODO: Once we support courses with unicode characters, we will need to revisit this.
-    replacement_char = u'-'
-    course_dir = replacement_char.join([course.id.org, course.id.course, course.id.run])
-    course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir)
+    course_dir = course.url_name
 
     export_course_to_xml(store, None, course.id, root_dir, course_dir)
 


### PR DESCRIPTION
**Ticket Link:** https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=EDS&modal=detail&selectedIssue=EDS-187&assignee=5b5f2693cd0f822d875303b3

**Problem:** The shell command **export_olx** was giving error of **file or dir not found** on video transcript (.srt ) files.

**Reason:** Error was due to directory structure conflicts between edx and edx-val (third party library used by edX).