### PR TITLE
Update register form title

### DIFF
--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -3,7 +3,7 @@
 
 <% if (!context.syncLearnerProfileData) { %>
 	<div class="toggle-form">
-		<span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
+		<span class="text"><%- gettext("Already have an account?") %></span>
 		<a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
 	</div>
 <% } %>


### PR DESCRIPTION
Update register form title from `Already have an {platformName} account?` to just `Already have an account?`

* Made this change in core `edx-platform` file so that its reflected on all themes
**Related PR:** https://github.com/edx/edx-platform/pull/15245

Before### 
<img width="960" alt="register form title" src="https://user-images.githubusercontent.com/5072991/78860227-14e66200-7a4b-11ea-9724-c3275c350265.png">

After### 
<img width="1369" alt="Screen Shot 2020-04-09 at 10 11 40 AM" src="https://user-images.githubusercontent.com/5072991/78860234-1f086080-7a4b-11ea-99d1-35f5e64bf26b.png">

