### PR TITLE
Show only organization that is link with site

### DIFF
--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -3,9 +3,11 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+from django.contrib.sites.shortcuts import get_current_site
+
+from openedx.features.edly.models import EdlySubOrganization
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-from util.organizations_helpers import get_organizations
 
 
 class OrganizationListView(View):
@@ -18,6 +20,10 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
-        organizations = get_organizations()
-        org_names_list = [(org["short_name"]) for org in organizations]
+
+        current_site = get_current_site(request)
+
+        edly_sub_organization = EdlySubOrganization.objects.filter(studio_site=current_site.id)
+
+        org_names_list = [(org.edx_organization.short_name ) for org in edly_sub_organization]
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -7,6 +7,7 @@ from django.views.generic import View
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.features.edly.utils import get_enabled_organizations
 
+
 class OrganizationListView(View):
     """View rendering organization list as json.
 

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -19,5 +19,4 @@ class OrganizationListView(View):
         """Returns organization list as json."""
         organizations = get_enabled_organizations(request)
         org_names_list = [(org["short_name"]) for org in organizations]
-
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -3,12 +3,12 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from django.contrib.sites.shortcuts import get_current_site
-
-from openedx.features.edly.models import EdlySubOrganization
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-
+from util.organizations_helpers import get_organizations
+from openedx.features.edly.utils import get_edly_organizations
+from django.conf import settings
+import waffle
 
 class OrganizationListView(View):
     """View rendering organization list as json.
@@ -20,7 +20,12 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
-        current_site = get_current_site(request)
-        edly_sub_organization = EdlySubOrganization.objects.filter(studio_site=current_site.id)
-        org_names_list = [(org.edx_organization.short_name ) for org in edly_sub_organization]
+
+        if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS):
+            organizations = get_organizations()
+            org_names_list = [(org["short_name"]) for org in organizations]
+        else:
+            organizations = get_edly_organizations(request)
+            org_names_list = [(org.edx_organization.short_name ) for org in organizations]
+
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -20,10 +20,7 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
-
         current_site = get_current_site(request)
-
         edly_sub_organization = EdlySubOrganization.objects.filter(studio_site=current_site.id)
-
         org_names_list = [(org.edx_organization.short_name ) for org in edly_sub_organization]
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -5,7 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-from openedx.features.edly.utils import get_enabled_organization
+from openedx.features.edly.utils import get_enabled_organizations
 
 class OrganizationListView(View):
     """View rendering organization list as json.
@@ -17,7 +17,7 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
-        organizations = get_enabled_organization(request)
-        org_names_list = [(org['short_name']) for org in organizations]
+        organizations = get_enabled_organizations(request)
+        org_names_list = [(org["short_name"]) for org in organizations]
 
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -5,10 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
-from util.organizations_helpers import get_organizations
-from openedx.features.edly.utils import get_edly_organizations
-from django.conf import settings
-import waffle
+from openedx.features.edly.utils import get_enabled_organization
 
 class OrganizationListView(View):
     """View rendering organization list as json.
@@ -20,12 +17,7 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         """Returns organization list as json."""
-
-        if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS):
-            organizations = get_organizations()
-            org_names_list = [(org["short_name"]) for org in organizations]
-        else:
-            organizations = get_edly_organizations(request)
-            org_names_list = [(org.edx_organization.short_name ) for org in organizations]
+        organizations = get_enabled_organization(request)
+        org_names_list = [(org['short_name']) for org in organizations]
 
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -1,25 +1,15 @@
 """Tests covering the Organizations listing on the Studio home."""
 import json
-import logging
 
-from django.conf import settings
-from django.test import TestCase
 from django.urls import reverse
+from django.test import TestCase
 from mock import patch
-from testfixtures import LogCapture
-from waffle.testutils import override_switch
 
-from openedx.features.edly.tests.factories import (EdlyOrganizationFactory,
-                                                   EdlySubOrganizationFactory,
-                                                   SiteFactory,)
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
 
-LOGGER_NAME = 'openedx.features.edly.utils'
-
 
 @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
-@override_switch(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH, active=False)
 class TestOrganizationListing(TestCase):
     """Verify Organization listing behavior."""
     @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
@@ -42,62 +32,3 @@ class TestOrganizationListing(TestCase):
         self.assertEqual(response.status_code, 200)
         org_names = json.loads(response.content)
         self.assertEqual(org_names, self.org_short_names)
-
-
-@patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
-@override_switch(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH, active=True)
-class TestEdlyOrganizationListing(TestCase):
-    """
-    Verify Organization listing behavior.
-    """
-    @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
-    def setUp(self):
-        super(TestEdlyOrganizationListing, self).setUp()
-        self.staff = UserFactory(is_staff=True)
-        self.client.login(username=self.staff.username, password='test')
-        self.org_names_listing_url = reverse('organizations')
-
-    def test_without_authentication(self):
-        """
-        Verify authentication is required when accessing the endpoint.
-        """
-        self.client.logout()
-        response = self.client.get(self.org_names_listing_url)
-        assert response.status_code == 302
-
-    def test_organization_list(self):
-        """
-        Verify that the organization names list API only returns Edly's enabled organizations.
-        """
-        studio_site = SiteFactory()
-        edly_organization = EdlyOrganizationFactory(name='Test Edly Organization Name')
-        edly_sub_organization = EdlySubOrganizationFactory(
-            studio_site=studio_site,
-            edly_organization=edly_organization
-        )
-
-        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
-
-        assert response.status_code == 200
-        assert len(response.json()) == 1
-        assert response.json()[0] == edly_sub_organization.edx_organization.short_name
-
-    def test_organization_list_without_linked_edly_sub_organization(self):
-        """
-        The organization names list API returns empty response when there is no
-        linked "EdlySubOrganization" with the studio site.
-        """
-        studio_site = SiteFactory()
-        with LogCapture(LOGGER_NAME) as logger:
-            response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
-
-            logger.check(
-                (
-                    LOGGER_NAME,
-                    'ERROR',
-                    'No EdlySubOrganization found for site {}'.format(studio_site)
-                )
-            )
-
-            assert response.status_code == 200
-            assert response.json() == []

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -4,12 +4,15 @@ import json
 from django.urls import reverse
 from django.test import TestCase
 from mock import patch
+from waffle.testutils import override_switch
 
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
 from openedx.features.edly.tests.factories import EdlyOrganizationFactory, EdlySubOrganizationFactory, SiteFactory
+from django.conf import settings
 
 @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
+@override_switch(settings.ENABLE_EDLY_ORGANIZATIONS, active=False)
 class TestOrganizationListing(TestCase):
     """Verify Organization listing behavior."""
     @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
@@ -18,6 +21,40 @@ class TestOrganizationListing(TestCase):
         self.staff = UserFactory(is_staff=True)
         self.client.login(username=self.staff.username, password='test')
         self.org_names_listing_url = reverse('organizations')
+        self.org_short_names = ["alphaX", "betaX", "orgX"]
+        for index, short_name in enumerate(self.org_short_names):
+            add_organization(organization_data={
+                'name': 'Test Organization %s' % index,
+                'short_name': short_name,
+                'description': 'Testing Organization %s Description' % index,
+            })
+
+    def test_organization_list(self):
+        """Verify that the organization names list api returns list of organization short names."""
+        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, 200)
+        org_names = json.loads(response.content)
+        self.assertEqual(org_names, self.org_short_names)
+
+
+@patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
+@override_switch(settings.ENABLE_EDLY_ORGANIZATIONS, active=True)
+class TestEdlyOrganizationListing(TestCase):
+    """Verify Organization listing behavior."""
+    @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
+    def setUp(self):
+        super(TestEdlyOrganizationListing, self).setUp()
+        self.staff = UserFactory(is_staff=True)
+        self.client.login(username=self.staff.username, password='test')
+        self.org_names_listing_url = reverse('organizations')
+
+    def test_without_authentication(self):
+        """
+        Verify authentication is required when accessing the endpoint.
+        """
+        self.client.logout()
+        response = self.client.get(self.org_names_listing_url)
+        self.assertEqual(response.status_code, 302)
 
     def test_organization_list(self):
         """
@@ -41,3 +78,10 @@ class TestOrganizationListing(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()[0], edly_sub_organization.edx_organization.short_name)
+
+
+        studio_site_2 = SiteFactory()
+        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site_2.domain)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -1,15 +1,15 @@
 """Tests covering the Organizations listing on the Studio home."""
 import json
+import logging
 
-from django.urls import reverse
+from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 from mock import patch
-from waffle.testutils import override_switch
-
+from openedx.features.edly.tests.factories import EdlyOrganizationFactory, EdlySubOrganizationFactory, SiteFactory
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
-from openedx.features.edly.tests.factories import EdlyOrganizationFactory, EdlySubOrganizationFactory, SiteFactory
-from django.conf import settings
+from waffle.testutils import override_switch
 
 @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
 @override_switch(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH, active=False)
@@ -56,7 +56,7 @@ class TestEdlyOrganizationListing(TestCase):
         """
         self.client.logout()
         response = self.client.get(self.org_names_listing_url)
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_organization_list(self):
         """
@@ -72,9 +72,9 @@ class TestEdlyOrganizationListing(TestCase):
 
         response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 1)
-        self.assertEqual(response.json()[0], edly_sub_organization.edx_organization.short_name)
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0] == edly_sub_organization.edx_organization.short_name
 
         """
         Now verify that if there is no "EdlySubOrganization" linked to a studio site the organization names list API returns empty response.
@@ -82,5 +82,5 @@ class TestEdlyOrganizationListing(TestCase):
         studio_site_2 = SiteFactory()
         response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site_2.domain)
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), [])
+        assert response.status_code == 200
+        assert response.json() == []

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from mock import patch
 from testfixtures import LogCapture
 from waffle.testutils import override_switch
+
 from openedx.features.edly.tests.factories import (EdlyOrganizationFactory,
                                                    EdlySubOrganizationFactory,
                                                    SiteFactory,)
@@ -68,7 +69,6 @@ class TestEdlyOrganizationListing(TestCase):
         """
         Verify that the organization names list API only returns Edly's enabled organizations.
         """
-
         studio_site = SiteFactory()
         edly_organization = EdlyOrganizationFactory(name='Test Edly Organization Name')
         edly_sub_organization = EdlySubOrganizationFactory(
@@ -84,7 +84,8 @@ class TestEdlyOrganizationListing(TestCase):
 
     def test_organization_list_without_linked_edly_sub_organization(self):
         """
-        Verify that if there is no "EdlySubOrganization" linked to a studio site the organization names list API returns empty response.
+        The organization names list API returns empty response when there is no
+        linked "EdlySubOrganization" with the studio site.
         """
         studio_site = SiteFactory()
         with LogCapture(LOGGER_NAME) as logger:

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -10,7 +10,7 @@ from testfixtures import LogCapture
 from waffle.testutils import override_switch
 from openedx.features.edly.tests.factories import (EdlyOrganizationFactory,
                                                    EdlySubOrganizationFactory,
-                                                   SiteFactory)
+                                                   SiteFactory,)
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
 

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -7,7 +7,7 @@ from mock import patch
 
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
-
+from openedx.features.edly.tests.factories import EdlyOrganizationFactory, EdlySubOrganizationFactory, SiteFactory
 
 @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
 class TestOrganizationListing(TestCase):
@@ -18,17 +18,26 @@ class TestOrganizationListing(TestCase):
         self.staff = UserFactory(is_staff=True)
         self.client.login(username=self.staff.username, password='test')
         self.org_names_listing_url = reverse('organizations')
-        self.org_short_names = ["alphaX", "betaX", "orgX"]
-        for index, short_name in enumerate(self.org_short_names):
-            add_organization(organization_data={
-                'name': 'Test Organization %s' % index,
-                'short_name': short_name,
-                'description': 'Testing Organization %s Description' % index,
-            })
 
     def test_organization_list(self):
-        """Verify that the organization names list api returns list of organization short names."""
-        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json')
+        """
+        Verify that the organization names list api returns list of organization short names.
+        """
+
+        studio_site = SiteFactory()
+        edly_organization = EdlyOrganizationFactory(name='Test Edly Organization Name')
+        edly_sub_organization = EdlySubOrganizationFactory(
+            name='Test Edly Sub Organization Name',
+            slug='test-edly-sub-organization-name',
+            studio_site=studio_site,
+            edly_organization=edly_organization
+        )
+
+        organization = edly_sub_organization.edx_organization
+        organization.short_name  = 'test-edx-organization'
+        organization.save();
+
+        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
+
         self.assertEqual(response.status_code, 200)
-        org_names = json.loads(response.content)
-        self.assertEqual(org_names, self.org_short_names)
+        self.assertEqual(response.json()[0], edly_sub_organization.edx_organization.short_name)

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -33,9 +33,9 @@ class TestOrganizationListing(TestCase):
             edly_organization=edly_organization
         )
 
-        organization = edly_sub_organization.edx_organization
-        organization.short_name  = 'test-edx-organization'
-        organization.save();
+        edx_organization = edly_sub_organization.edx_organization
+        edx_organization.short_name  = 'test-edx-organization'
+        edx_organization.save();
 
         response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
 

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -66,19 +66,14 @@ class TestEdlyOrganizationListing(TestCase):
         studio_site = SiteFactory()
         edly_organization = EdlyOrganizationFactory(name='Test Edly Organization Name')
         edly_sub_organization = EdlySubOrganizationFactory(
-            name='Test Edly Sub Organization Name',
-            slug='test-edly-sub-organization-name',
             studio_site=studio_site,
             edly_organization=edly_organization
         )
 
-        edx_organization = edly_sub_organization.edx_organization
-        edx_organization.short_name = 'test-edx-organization'
-        edx_organization.save()
-
         response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
         self.assertEqual(response.json()[0], edly_sub_organization.edx_organization.short_name)
 
         """

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -551,7 +551,7 @@ MIDDLEWARE_CLASSES = [
 ]
 
 # Edly Configuration
-ENABLE_EDLY_ORGANIZATIONS = 'enable_edly_organizations'
+ENABLE_EDLY_ORGANIZATIONS_SWITCH = 'enable_edly_organizations'
 
 # Clickjacking protection can be disabled by setting this to 'ALLOW'
 X_FRAME_OPTIONS = 'DENY'

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -550,6 +550,9 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
 
+# Edly Configuration
+ENABLE_EDLY_ORGANIZATIONS = 'enable_edly_organizations'
+
 # Clickjacking protection can be disabled by setting this to 'ALLOW'
 X_FRAME_OPTIONS = 'DENY'
 

--- a/openedx/features/edly/tests/test_organizations.py
+++ b/openedx/features/edly/tests/test_organizations.py
@@ -8,9 +8,11 @@ from mock import patch
 from testfixtures import LogCapture
 from waffle.testutils import override_switch
 
-from openedx.features.edly.tests.factories import (EdlyOrganizationFactory,
-                                                   EdlySubOrganizationFactory,
-                                                   SiteFactory,)
+from openedx.features.edly.tests.factories import (
+  EdlyOrganizationFactory,
+  EdlySubOrganizationFactory,
+  SiteFactory,
+)
 from student.tests.factories import UserFactory
 from util.organizations_helpers import add_organization
 
@@ -57,6 +59,8 @@ class TestEdlyOrganizationListing(TestCase):
 
     def test_organization_list_without_linked_edly_sub_organization(self):
         """
+        Verify that organization list API returns empty response without enabled organizations.
+
         The organization names list API returns empty response when there is no
         linked "EdlySubOrganization" with the studio site.
         """

--- a/openedx/features/edly/tests/test_organizations.py
+++ b/openedx/features/edly/tests/test_organizations.py
@@ -1,0 +1,76 @@
+"""Tests covering the Organizations listing on the Studio home."""
+import logging
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+from mock import patch
+from testfixtures import LogCapture
+from waffle.testutils import override_switch
+
+from openedx.features.edly.tests.factories import (EdlyOrganizationFactory,
+                                                   EdlySubOrganizationFactory,
+                                                   SiteFactory,)
+from student.tests.factories import UserFactory
+from util.organizations_helpers import add_organization
+
+LOGGER_NAME = 'openedx.features.edly.utils'
+
+
+@patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
+@override_switch(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH, active=True)
+class TestEdlyOrganizationListing(TestCase):
+    """
+    Verify Organization listing behavior.
+    """
+    @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
+    def setUp(self):
+        super(TestEdlyOrganizationListing, self).setUp()
+        self.staff = UserFactory(is_staff=True)
+        self.client.login(username=self.staff.username, password='test')
+        self.org_names_listing_url = reverse('organizations')
+
+    def test_without_authentication(self):
+        """
+        Verify authentication is required when accessing the endpoint.
+        """
+        self.client.logout()
+        response = self.client.get(self.org_names_listing_url)
+        assert response.status_code == 302
+
+    def test_organization_list(self):
+        """
+        Verify that the organization names list API only returns Edly's enabled organizations.
+        """
+        studio_site = SiteFactory()
+        edly_organization = EdlyOrganizationFactory(name='Test Edly Organization Name')
+        edly_sub_organization = EdlySubOrganizationFactory(
+            studio_site=studio_site,
+            edly_organization=edly_organization
+        )
+
+        response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
+
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0] == edly_sub_organization.edx_organization.short_name
+
+    def test_organization_list_without_linked_edly_sub_organization(self):
+        """
+        The organization names list API returns empty response when there is no
+        linked "EdlySubOrganization" with the studio site.
+        """
+        studio_site = SiteFactory()
+        with LogCapture(LOGGER_NAME) as logger:
+            response = self.client.get(self.org_names_listing_url, HTTP_ACCEPT='application/json', SERVER_NAME=studio_site.domain)
+
+            logger.check(
+                (
+                    LOGGER_NAME,
+                    'ERROR',
+                    'No EdlySubOrganization found for site {}'.format(studio_site)
+                )
+            )
+
+            assert response.status_code == 200
+            assert response.json() == []

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -4,6 +4,7 @@ import jwt
 import waffle
 from django.conf import settings
 from django.forms.models import model_to_dict
+
 from openedx.features.edly.models import EdlySubOrganization
 from util.organizations_helpers import get_organizations
 
@@ -43,11 +44,11 @@ def get_enabled_organizations(request):
 
     if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH):
         return get_organizations()
-    else:
-        try:
-          studio_site_edx_organization = model_to_dict(request.site.studio_site.edx_organization)
-        except EdlySubOrganization.DoesNotExist:
-          LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
-          return []
+
+    try:
+        studio_site_edx_organization = request.site.studio_site.edx_organization
+    except EdlySubOrganization.DoesNotExist:
+        LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
+        return []
 
     return [studio_site_edx_organization]

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -45,9 +45,9 @@ def get_enabled_organizations(request):
         return get_organizations()
     else:
         try:
-          studio_site_edx_organization = [model_to_dict(request.site.studio_site.edx_organization)]
+          studio_site_edx_organization = model_to_dict(request.site.studio_site.edx_organization)
         except EdlySubOrganization.DoesNotExist:
           LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
-          studio_site_edx_organization = []
+          return []
 
-    return studio_site_edx_organization
+    return [studio_site_edx_organization]

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,0 +1,11 @@
+from django.contrib.sites.shortcuts import get_current_site
+from openedx.features.edly.models import EdlySubOrganization
+
+
+def get_edly_organizations(request):
+  """
+  Returns Organization base on request site.
+  """
+  current_site = get_current_site(request)
+  edly_organizations = EdlySubOrganization.objects.filter(studio_site=current_site.id)
+  return edly_organizations

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,6 +1,7 @@
 import jwt
 import waffle
 from django.conf import settings
+from django.forms.models import model_to_dict
 from openedx.features.edly.models import EdlySubOrganization
 from util.organizations_helpers import get_organizations
 
@@ -43,7 +44,7 @@ def get_enabled_organization(request):
         organizations = get_organizations()
     else:
         try:
-          organizations = [request.site.studio_site.edx_organization.__dict__]
+          organizations = [model_to_dict(request.site.studio_site.edx_organization)]
         except EdlySubOrganization.DoesNotExist:
           organizations = []
 

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -46,7 +46,7 @@ def get_enabled_organizations(request):
         return get_organizations()
 
     try:
-        studio_site_edx_organization = request.site.studio_site.edx_organization
+        studio_site_edx_organization = model_to_dict(request.site.studio_site.edx_organization)
     except EdlySubOrganization.DoesNotExist:
         LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
         return []

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -43,8 +43,9 @@ def get_enabled_organization(request):
     if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH):
         organizations = get_organizations()
     else:
-        current_site = get_current_site(request)
-        edly_organizations = EdlySubOrganization.objects.filter(studio_site=current_site.id)
-        organizations = [(org.edx_organization.__dict__) for org in edly_organizations]
+        try:
+          organizations = [request.site.studio_site.edx_organization.__dict__]
+        except EdlySubOrganization.DoesNotExist:
+          organizations = []
 
     return organizations

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -21,7 +21,6 @@ def encode_edly_user_info_cookie(cookie_data):
     """
     return jwt.encode(cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM)
 
-
 def decode_edly_user_info_cookie(encoded_cookie_data):
     """
     Decode edly_user_info cookie data from JWT string.
@@ -33,7 +32,6 @@ def decode_edly_user_info_cookie(encoded_cookie_data):
         dict
     """
     return jwt.decode(encoded_cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithms=[settings.EDLY_JWT_ALGORITHM])
-
 
 def get_enabled_organizations(request):
     """

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,11 +1,22 @@
+import waffle
+from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from openedx.features.edly.models import EdlySubOrganization
+from util.organizations_helpers import get_organizations
 
+def get_enabled_organization(request):
+  """
+  Helper method to get linked organizations for request site.
 
-def get_edly_organizations(request):
+  Returns:
+      list: List of linked organizations for request site
   """
-  Returns Organization base on request site.
-  """
-  current_site = get_current_site(request)
-  edly_organizations = EdlySubOrganization.objects.filter(studio_site=current_site.id)
-  return edly_organizations
+
+  if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH):
+      organizations = get_organizations()
+  else:
+      current_site = get_current_site(request)
+      edly_organizations = EdlySubOrganization.objects.filter(studio_site=current_site.id)
+      organizations = [(org.edx_organization.__dict__) for org in edly_organizations]
+
+  return organizations

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,7 +1,6 @@
 import jwt
 import waffle
 from django.conf import settings
-from django.contrib.sites.shortcuts import get_current_site
 from openedx.features.edly.models import EdlySubOrganization
 from util.organizations_helpers import get_organizations
 


### PR DESCRIPTION
This PR updates the `organizations` endpoint and show the only organization that is linked with the site. Before this, all the organization were shown.
 
To show the organizations base of the website, we need to enable `enable_edly_organizations` waffle in studio.

Jira ticket: https://edlyio.atlassian.net/browse/EDLY-1295

![image](https://user-images.githubusercontent.com/7139602/81175382-e366a500-8fbc-11ea-9ce4-690e44845c37.png)


![image](https://user-images.githubusercontent.com/7139602/81175970-d7c7ae00-8fbd-11ea-8615-fa43a28585f7.png)

