### PR TITLE
Set edly-user-info cookie at login and delete at logout

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1350,6 +1350,10 @@ STUDIO_DOMAIN_PREFIX = 'studio.'
 
 CSRF_TRUSTED_ORIGINS = ['.edly.io']
 
+EDLY_USER_INFO_COOKIE_NAME = 'edly-user-info'
+EDLY_COOKIE_SECRET_KEY = 'EDLY-COOKIE-SECRET-KEY'
+EDLY_JWT_ALGORITHM = 'HS256'
+
 # Clickjacking protection can be disbaled by setting this to 'ALLOW'
 X_FRAME_OPTIONS = 'DENY'
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -185,6 +185,10 @@ EDXMKTG_USER_INFO_COOKIE_NAME = ENV_TOKENS.get('EDXMKTG_USER_INFO_COOKIE_NAME', 
 LMS_ROOT_URL = ENV_TOKENS.get('LMS_ROOT_URL')
 LMS_INTERNAL_ROOT_URL = ENV_TOKENS.get('LMS_INTERNAL_ROOT_URL', LMS_ROOT_URL)
 
+# Edly Configuration
+EDLY_COOKIE_SECRET_KEY = ENV_TOKENS.get('EDLY_COOKIE_SECRET_KEY', EDLY_COOKIE_SECRET_KEY)
+
+
 # List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
 # IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
 IDA_LOGOUT_URI_LIST = ENV_TOKENS.get('IDA_LOGOUT_URI_LIST', [])

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -26,6 +26,7 @@ from openedx.core.djangoapps.password_policy import compliance as password_polic
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangolib.markup import HTML, Text
+from openedx.features.edly.cookies import set_logged_in_edly_cookies
 from student.models import LoginFailures
 from student.views import send_reactivation_email_for_user
 from student.forms import send_password_reset_email_for_user
@@ -372,6 +373,7 @@ def login_user(request):
 
         # Ensure that the external marketing site can
         # detect that the user is logged in.
+        set_logged_in_edly_cookies(request, response, possibly_authenticated_user)
         return set_logged_in_cookies(request, response, possibly_authenticated_user)
     except AuthFailedError as error:
         log.exception(error.get_response())

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView
 from provider.oauth2.models import Client
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
+from openedx.features.edly.cookies import delete_logged_in_edly_cookies
 
 
 class LogoutView(TemplateView):
@@ -65,6 +66,7 @@ class LogoutView(TemplateView):
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
+        delete_logged_in_edly_cookies(response)
 
         return response
 

--- a/openedx/features/edly/cookies.py
+++ b/openedx/features/edly/cookies.py
@@ -1,0 +1,68 @@
+from django.conf import settings
+
+from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
+from openedx.features.edly.models import EdlySubOrganization
+from openedx.features.edly.utils import encode_edly_user_info_cookie
+
+
+def set_logged_in_edly_cookies(request, response, user):
+    """
+    Set cookies for edly users at the time of login.
+
+    Arguments:
+        request (HttpRequest): The request to the view, used to calculate
+            the cookie's expiration date based on the session expiration date.
+        response (HttpResponse): The response on which the cookie will be set.
+        user (User): The currently logged in user.
+
+    Returns:
+        HttpResponse
+
+    """
+    if user.is_authenticated and not user.is_anonymous:
+        cookie_settings = standard_cookie_settings(request)
+        edly_cookie_string = _get_edly_user_info_cookie_string(request)
+
+        response.set_cookie(
+            settings.EDLY_USER_INFO_COOKIE_NAME,
+            edly_cookie_string,
+            **cookie_settings
+        )
+
+    return response
+
+
+def delete_logged_in_edly_cookies(response):
+    """
+    Delete edly user info cookie.
+
+    Arguments:
+        response (HttpResponse): The response sent to the client.
+
+    Returns:
+        HttpResponse
+    """
+    response.delete_cookie(settings.EDLY_USER_INFO_COOKIE_NAME)
+
+    return response
+
+def _get_edly_user_info_cookie_string(request):
+    """
+    Returns JWT encoded cookie string with edly user info.
+
+    Arguments:
+        request (HttpRequest): Django request object
+
+    Returns:
+        string
+    """
+    try:
+        edly_sub_organization = request.site.lms_site
+        edly_user_info_cookie_data = {
+            'edly-org': edly_sub_organization.edly_organization.slug,
+            'edly-sub-org': edly_sub_organization.slug,
+            'edx-org': edly_sub_organization.edx_organization.short_name
+        }
+        return encode_edly_user_info_cookie(edly_user_info_cookie_data)
+    except EdlySubOrganization.DoesNotExist:
+        return ''

--- a/openedx/features/edly/tests/test_cookies.py
+++ b/openedx/features/edly/tests/test_cookies.py
@@ -1,0 +1,84 @@
+import jwt
+from mock import MagicMock, patch
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+
+from openedx.features.edly.tests.factories import SiteFactory, EdlySubOrganizationFactory
+from openedx.features.edly import cookies as cookies_api
+from student.tests.factories import UserFactory
+
+
+class CookieTests(TestCase):
+    """
+    Test cases for Edly cookie methods.
+    """
+
+    def setUp(self):
+        """
+        Setup initial test data
+        """
+        super(CookieTests, self).setUp()
+        self.user = UserFactory.create()
+        self.request = RequestFactory().get('/')
+        self.request.user = self.user
+        self.request.session = self._get_stub_session()
+        self.request.site = SiteFactory()
+
+    def _get_stub_session(self, expire_at_browser_close=False, max_age=604800):
+        return MagicMock(
+            get_expire_at_browser_close=lambda: expire_at_browser_close,
+            get_expiry_age=lambda: max_age,
+        )
+
+    def _create_edly_sub_organization(self):
+        """
+        Helper method to create 'EdlySubOrganization` for the request site.
+        """
+        return EdlySubOrganizationFactory(lms_site=self.request.site)
+
+    def test_get_edly_cookie_string(self):
+        """
+        Tests that edly cookie string is generated correctly.
+        """
+        edly_sub_organization = self._create_edly_sub_organization()
+        actual_cookie_string = cookies_api._get_edly_user_info_cookie_string(self.request)  # pylint: disable=protected-access
+        expected_cookie_string = jwt.encode(
+            {
+                'edly-org': edly_sub_organization.edly_organization.slug,
+                'edly-sub-org': edly_sub_organization.slug,
+                'edx-org': edly_sub_organization.edx_organization.short_name
+            },
+            settings.EDLY_COOKIE_SECRET_KEY,
+            algorithm=settings.EDLY_JWT_ALGORITHM
+        )
+
+        assert actual_cookie_string == expected_cookie_string
+
+    def test_set_logged_in_edly_cookies(self):
+        """
+        Tests that Edly user info cookie is set correctly.
+        """
+        self._create_edly_sub_organization()
+        response = cookies_api.set_logged_in_edly_cookies(self.request, HttpResponse(), self.user)
+        assert settings.EDLY_USER_INFO_COOKIE_NAME in response.cookies
+
+    def test_set_logged_in_edly_cookies_with_no_edly_sub_organiztion(self):
+        """
+        Tests that Edly user info cookie is set to empty in absence of edly sub-organization.
+        """
+        response = cookies_api.set_logged_in_edly_cookies(self.request, HttpResponse(), self.user)
+        assert settings.EDLY_USER_INFO_COOKIE_NAME in response.cookies
+        assert response.cookies.get(settings.EDLY_USER_INFO_COOKIE_NAME).value == ''
+
+    def test_delete_logged_in_edly_cookies(self):
+        """
+        Tests that Edly user info cookie is deleted correctly.
+        """
+        self._create_edly_sub_organization()
+        response = cookies_api.set_logged_in_edly_cookies(self.request, HttpResponse(), self.user)
+        assert settings.EDLY_USER_INFO_COOKIE_NAME in response.cookies
+
+        cookies_api.delete_logged_in_edly_cookies(response)
+        assert not response.cookies.get(settings.EDLY_USER_INFO_COOKIE_NAME).value

--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -1,0 +1,37 @@
+import jwt
+from django.conf import settings
+from django.test import TestCase
+
+from openedx.features.edly.utils import encode_edly_user_info_cookie, decode_edly_user_info_cookie
+
+
+class UtilsTests(TestCase):
+    """
+    Tests for utility methods.
+    """
+
+    def setUp(self):
+        """
+        Setup initial test data
+        """
+        self.test_edly_user_info_cookie_data = {
+            'edly-org': 'edly',
+            'edly-sub-org': 'cloud',
+            'edx-org': 'cloudX'
+        }
+
+    def test_encode_edly_user_info_cookie(self):
+        """
+        Test that "encode_edly_user_info_cookie" method encodes data correctly.
+        """
+        actual_encoded_string = encode_edly_user_info_cookie(self.test_edly_user_info_cookie_data)
+        expected_encoded_string = jwt.encode(self.test_edly_user_info_cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM)
+        assert actual_encoded_string == expected_encoded_string
+
+    def test_decode_edly_user_info_cookie(self):
+        """
+        Test that "decode_edly_user_info_cookie" method decodes data correctly.
+        """
+        encoded_data = jwt.encode(self.test_edly_user_info_cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM)
+        decoded_edly_user_info_cookie_data = decode_edly_user_info_cookie(encoded_data)
+        assert self.test_edly_user_info_cookie_data == decoded_edly_user_info_cookie_data

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,0 +1,27 @@
+import jwt
+from django.conf import settings
+
+
+def encode_edly_user_info_cookie(cookie_data):
+    """
+    Encode edly_user_info cookie data into JWT string.
+
+    Arguments:
+        cookie_data (dict): Edly user info cookie dict.
+
+    Returns:
+        string
+    """
+    return jwt.encode(cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithm=settings.EDLY_JWT_ALGORITHM)
+
+def decode_edly_user_info_cookie(encoded_cookie_data):
+    """
+    Decode edly_user_info cookie data from JWT string.
+
+    Arguments:
+        encoded_cookie_data (dict): Edly user info cookie JWT encoded string.
+
+    Returns:
+        dict
+    """
+    return jwt.decode(encoded_cookie_data, settings.EDLY_COOKIE_SECRET_KEY, algorithms=[settings.EDLY_JWT_ALGORITHM])


### PR DESCRIPTION
**Description:**
Adds methods to set and remove `edly-user-info` cookie with Edly organization, Edly sub organizations and edx organizations details on login and logout. Also adds util methods to encode and decode cookie data to jwt strings.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1292

**Testing instructions:**

1. Create Edly organization and edly sub organization from LMS django admin.
2. Login through oauth into LMS
3. Open Application tab in inspect element.
4. Expect a cookie `edly-user-info` there with a JWT encoded string as value.
5. Logout.
6. `edly-user-info` cookie should be gone.

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.