### PR TITLE
Show only linked organization in create library form

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -154,6 +154,7 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
             $cancelButton.bind('click', makeCancelHandler('library'));
             CancelOnEscape($cancelButton);
 
+            CreateLibraryUtils.setupOrgAutocomplete();
             CreateLibraryUtils.configureHandlers();
         };
 

--- a/cms/static/js/views/utils/create_library_utils.js
+++ b/cms/static/js/views/utils/create_library_utils.js
@@ -30,5 +30,18 @@ define(['jquery', 'gettext', 'common/js/components/utils/view_utils', 'js/views/
                     errorHandler(reason);
                 });
             };
+
+            this.setupOrgAutocomplete = function () {
+                $.getJSON('/organizations', function (data) {
+                    $.each(data, function (i, item) {
+                        $(selectors.org).append(
+                            $('<option>', {
+                                value: item,
+                                text: item,
+                            })
+                        );
+                    });
+                });
+            };
         };
     });

--- a/cms/static/js/views/utils/create_utils_base.js
+++ b/cms/static/js/views/utils/create_utils_base.js
@@ -81,7 +81,7 @@ define(['jquery', 'underscore', 'gettext', 'common/js/components/utils/view_util
                     self.keyFieldSelectors,
                     function(element) {
                         var $element = $(element);
-                        var $event = $element.selector == '.new-course-org' ? 'change' : 'keyup';
+                        var $event = $element.selector == '.new-course-org' || '.new-library-org' ? 'change' : 'keyup';
                         $element.on($event, function(event) {
                             // Don't bother showing "required field" error when
                             // the user tabs into a new field; this is distracting

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -157,7 +157,9 @@ from openedx.core.djangolib.js_utils import (
                 </li>
                 <li class="field text required">
                   <label for="new-library-org">${_("Organization")}</label>
-                  <input class="new-library-org" id="new-library-org" type="text" name="new-library-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-library-org tip-error-new-library-org" />
+                  <select class="new-library-org" id="new-library-org" type="text" name="new-library-org" required aria-describedby="tip-new-library-org tip-error-new-library-org">
+                    <option value="" selected >${_('Select the organization')}</option>
+                  </select>
                   <span class="tip" id="tip-new-library-org">${_("The public organization name for your library.")} ${_("This cannot be changed.")}</span>
                   <span class="tip tip-error is-hiding" id="tip-error-new-library-org"></span>
                 </li>


### PR DESCRIPTION
**Description:**  This PR adds the following implementation:

- Convert text organizations field in the dropdown field for create library form .

- Show only linked organization in Library Form.


**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1296

**Related PR:** https://github.com/edly-io/edly-edx-themes/pull/165

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
![image](https://user-images.githubusercontent.com/7139602/81648945-f2c87100-9448-11ea-857b-b9b7c08ef87d.png)
