### PR TITLE
LMS/Studio give 404 if user has no access to request site

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -546,12 +546,17 @@ MIDDLEWARE_CLASSES = [
 
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 
+    'openedx.features.edly.middleware.EdlyOrganizationAccessMiddleware',
+
     # This must be last so that it runs first in the process_response chain
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
 
 # Edly Configuration
 ENABLE_EDLY_ORGANIZATIONS_SWITCH = 'enable_edly_organizations'
+EDLY_USER_INFO_COOKIE_NAME = 'edly-user-info'
+EDLY_COOKIE_SECRET_KEY = 'EDLY-COOKIE-SECRET-KEY'
+EDLY_JWT_ALGORITHM = 'HS256'
 
 # Clickjacking protection can be disabled by setting this to 'ALLOW'
 X_FRAME_OPTIONS = 'DENY'

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1327,6 +1327,8 @@ MIDDLEWARE_CLASSES = [
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 
+    'openedx.features.edly.middleware.EdlyOrganizationAccessMiddleware',
+
     'edly_panel_app.middleware.EdlyUserActivityMiddleware',
 ]
 

--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -1,0 +1,26 @@
+"""
+Edly Organization Access Middleware.
+"""
+from logging import getLogger
+from django.http import Http404
+
+from openedx.features.edly.utils import user_has_edly_organization_access
+
+logger = getLogger(__name__)
+
+
+class EdlyOrganizationAccessMiddleware(object):
+    """
+    Django middleware to validate edly user organization access based on request.
+    """
+
+    def process_request(self, request):
+        """
+        Validate logged in user's access based on request site and its linked edly sub organization.
+        """
+
+        user_is_authenticated = request.user.is_authenticated
+        user_is_superuser = request.user.is_superuser
+        if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
+            logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
+            raise Http404()

--- a/openedx/features/edly/tests/test_middleware.py
+++ b/openedx/features/edly/tests/test_middleware.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for Middleware.
+"""
+from testfixtures import LogCapture
+from django.conf import settings
+from django.test import TestCase
+from django.test.client import Client, RequestFactory
+
+from openedx.features.edly import cookies
+from openedx.features.edly.tests.factories import (
+    EdlySubOrganizationFactory,
+    EdlyUserFactory,
+    SiteFactory,
+)
+
+LOGGER_NAME = 'openedx.features.edly.middleware'
+
+
+class EdlyOrganizationAccessMiddlewareTests(TestCase):
+
+    def setUp(self):
+        self.user = EdlyUserFactory()
+        self.request = RequestFactory().get('/')
+        self.request.user = self.user
+        self.request.site = SiteFactory()
+
+        self.client = Client(SERVER_NAME=self.request.site.domain)
+        self.client.login(username=self.user.username, password='test')
+
+    def test_user_with_edly_organization_access(self):
+        """
+        Test logged in user access based on user's linked edly sub organization.
+        """
+        EdlySubOrganizationFactory(lms_site=self.request.site)
+        self.client.cookies.load(
+            {
+                settings.EDLY_USER_INFO_COOKIE_NAME: cookies._get_edly_user_info_cookie_string(self.request)
+            }
+        )
+
+        response = self.client.get('/', follow=True)
+        assert response.status_code == 200
+
+    def test_user_without_edly_organization_access(self):
+        """
+        Verify that logged in user gets valid error and log message response if user has no access.
+
+        Test that logged in user gets 404 and valid log message if user has no access for
+        request site's edly sub organization.
+        """
+
+        with LogCapture(LOGGER_NAME) as logger:
+            response = self.client.get('/', follow=True)
+            assert response.status_code == 404
+
+            logger.check(
+                (
+                    LOGGER_NAME,
+                    'ERROR',
+                    'Edly user %s has no access for site %s.' % (self.user.email, self.request.site)
+                )
+            )
+
+    def test_super_user_has_all_sites_access(self):
+        """
+        Test logged in super user has access to all sites.
+        """
+        edly_user = EdlyUserFactory(is_superuser=True)
+        client = Client()
+        client.login(username=edly_user.username, password='test')
+
+        response = client.get('/', follow=True)
+        assert response.status_code == 200

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -25,17 +25,22 @@ def user_has_edly_organization_access(request):
     Returns:
         bool: Returns True if User has Edly Organization Access Otherwise False.
     """
-    if not request.user.edly_profile:
+
+    if getattr(request.user, 'edly_profile', None) is None:
         return False
 
     current_site = request.site
-    edly_sub_org = EdlySubOrganization.objects.filter(
-        Q(lms_site=current_site) |
-        Q(studio_site=current_site)
-    ).first()
+
+    try:
+        edly_sub_org = EdlySubOrganization.objects.get(
+            Q(lms_site=current_site) |
+            Q(studio_site=current_site)
+        )
+    except EdlySubOrganization.DoesNotExist:
+        return False
 
     edly_user_info_cookie = request.COOKIES.get(settings.EDLY_USER_INFO_COOKIE_NAME, None)
-    if edly_sub_org and edly_sub_org.slug == get_edly_sub_org_from_cookie(edly_user_info_cookie):
+    if edly_sub_org.slug == get_edly_sub_org_from_cookie(edly_user_info_cookie):
         return True
 
     return False


### PR DESCRIPTION
**Description:**  This PR adds the following implementation:

- Add middleware to raise Http404 if the request site is not linked to the user’s edly sub-organization.

- Add Unit Tests for Middleware.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1322

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.