### PR TITLE
Removes -e flag from edly panel app requirement

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -42,7 +42,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-d
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
--e git+ssh://git@github.com/edly-io/edly-panel-edx-app.git@develop-multisite#egg=edly-panel-app
+git+ssh://git@github.com/edly-io/edly-panel-edx-app.git@develop-multisite#egg=edly-panel-app
 -e git+https://github.com/edly-io/xblock-video.git@dev#egg=video_xblock
 -e common/lib/xmodule
 alabaster==0.7.12         # via sphinx


### PR DESCRIPTION
**Description:** 
This PR removes `-e` flag from edly panel app requirement as it was not allowing tests to be run through `paver_test`.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1269

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**

- [ ] All reviewers approved
- <del>[ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
