### PR TITLE
Link users to  edly-sub-organization on registration

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -34,6 +34,8 @@ from openedx.core.djangoapps.user_api.serializers import CountryTimeZoneSerializ
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.views.register import create_account_with_params
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
+from openedx.features.edly.cookies import set_logged_in_edly_cookies
+from openedx.features.edly.utils import create_user_link_with_edly_sub_organization
 from student.helpers import AccountValidationError
 from util.json_request import JsonResponse
 
@@ -152,6 +154,7 @@ class RegistrationView(APIView):
 
         try:
             user = create_account_with_params(request, data)
+            create_user_link_with_edly_sub_organization(request, user)
         except AccountValidationError as err:
             errors = {
                 err.field: [{"user_message": text_type(err)}]
@@ -171,6 +174,7 @@ class RegistrationView(APIView):
 
         response = JsonResponse({"success": True})
         set_logged_in_cookies(request, response, user)
+        set_logged_in_edly_cookies(request, response, user)
         return response
 
     @method_decorator(transaction.non_atomic_requests)

--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -12,6 +12,7 @@ from django.test.client import RequestFactory
 from openedx.features.edly import cookies as cookies_api
 from openedx.features.edly.tests.factories import EdlySubOrganizationFactory, EdlyUserProfileFactory, SiteFactory
 from openedx.features.edly.utils import (
+    create_user_link_with_edly_sub_organization,
     decode_edly_user_info_cookie,
     encode_edly_user_info_cookie,
     get_edly_sub_org_from_cookie,
@@ -112,3 +113,13 @@ class UtilsTests(TestCase):
         edly_sub_organization = self._create_edly_sub_organization()
         edly_user_info_cookie = cookies_api._get_edly_user_info_cookie_string(self.request)
         assert edly_sub_organization.slug == get_edly_sub_org_from_cookie(edly_user_info_cookie)
+
+    def test_create_user_link_with_edly_sub_organization(self):
+        """
+        Test that "create_user_link_with_edly_sub_organization" method create "EdlyUserProfile" link with User.
+        """
+        user = UserFactory()
+        edly_sub_organization = self._create_edly_sub_organization()
+        edly_user_profile = create_user_link_with_edly_sub_organization(self.request, user)
+        assert edly_user_profile == user.edly_profile
+        assert edly_sub_organization.slug in user.edly_profile.get_linked_edly_sub_organizations

--- a/openedx/features/edly/tests/test_views.py
+++ b/openedx/features/edly/tests/test_views.py
@@ -44,3 +44,4 @@ class EdlyUserRegistrationTests(TestCase):
 
         edly_user = User.objects.get(username=username)
         assert hasattr(edly_user, 'edly_profile') == True
+        assert self.site.edly_sub_org_for_lms.slug in edly_user.edly_profile.get_linked_edly_sub_organizations

--- a/openedx/features/edly/tests/test_views.py
+++ b/openedx/features/edly/tests/test_views.py
@@ -1,0 +1,46 @@
+"""
+Tests for Edly User Registration.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from openedx.features.edly.tests.factories import EdlySubOrganizationFactory, SiteFactory
+
+
+class EdlyUserRegistrationTests(TestCase):
+    """
+    Tests for Edly User Registration.
+    """
+
+    def setUp(self):
+        """
+        Setup initial test data
+        """
+        super(EdlyUserRegistrationTests, self).setUp()
+        self.url = reverse('user_api_registration')
+        self.site = SiteFactory()
+
+    def test_edly_profile_creation_with_user_registration(self):
+        """
+        Test "EdlyUserProfile" creation on Registration of User.
+
+        Create an account with params, assert that the response indicates
+        success, and check if "EdlyUserProfile" object exists for the newly created user
+        """
+
+        EdlySubOrganizationFactory(lms_site=self.site)
+        username = 'test_user'
+        params = {
+            'email': 'test@example.org',
+            'name': 'Test User',
+            'username': username,
+            'password': 'test-pass',
+            'honor_code': 'true',
+        }
+
+        response = self.client.post(self.url, params, SERVER_NAME=self.site.domain)
+        assert response.status_code == 200
+
+        edly_user = User.objects.get(username=username)
+        assert hasattr(edly_user, 'edly_profile') == True

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import Q
 from django.forms.models import model_to_dict
 
-from openedx.features.edly.models import EdlySubOrganization
+from openedx.features.edly.models import EdlyUserProfile, EdlySubOrganization
 from util.organizations_helpers import get_organizations
 
 LOGGER = logging.getLogger(__name__)
@@ -108,3 +108,24 @@ def get_enabled_organizations(request):
         return []
 
     return [studio_site_edx_organization]
+
+
+def create_user_link_with_edly_sub_organization(request, user):
+    """
+    Create edly user profile link with edly sub organization.
+
+    Arguments:
+        request (WSGI Request): Django request object
+        user (object): User object.
+
+    Returns:
+        object: EdlyUserProfile object.
+
+    """
+    # User registration is possible only on LMS so we only get edly sub org for LMS site
+    edly_sub_org = request.site.edly_sub_org_for_lms
+    edly_user_profile, __ = EdlyUserProfile.objects.get_or_create(user=user)
+    edly_user_profile.edly_sub_organizations.add(edly_sub_org)
+    edly_user_profile.save()
+
+    return edly_user_profile


### PR DESCRIPTION
**Description:**  This PR adds the following implementation:

- Add a record in EdlyUserProfile with a link to the request site’s edly-sub-organization

- Set edly-user-info cookie on registration

- Add a test that on registration the user is now linked with the request site’s edly-sub-organization

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1273

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.