### PR TITLE
Adds middleware to override django settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -494,6 +494,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 
+    'openedx.features.edly.middleware.SettingsOverrideMiddleware',
+
     # Allows us to define redirects via Django admin
     'django_sites_extensions.middleware.RedirectMiddleware',
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1247,6 +1247,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 
+    'openedx.features.edly.middleware.SettingsOverrideMiddleware',
+
     # Allows us to define redirects via Django admin
     'django_sites_extensions.middleware.RedirectMiddleware',
 

--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -2,8 +2,11 @@
 Edly Organization Access Middleware.
 """
 from logging import getLogger
+from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404
 
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.features.edly.utils import user_has_edly_organization_access
 
 logger = getLogger(__name__)
@@ -24,3 +27,31 @@ class EdlyOrganizationAccessMiddleware(object):
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
             raise Http404()
+
+
+class SettingsOverrideMiddleware(object):
+    """
+    Django middleware to override django settings from site configuration.
+    """
+
+    def process_request(self, request):
+        """
+        Override django settings from django site configuration.
+        """
+        current_site = get_current_site(request)
+        try:
+            current_site_configuration = current_site.configuration
+        except SiteConfiguration.DoesNotExist:
+            logger.warning('Site (%s) has no related site configuration.', current_site)
+            return None
+
+        if current_site_configuration.values:
+            django_settings_override_values = current_site_configuration.get_value('DJANGO_SETTINGS_OVERRIDE', None)
+            if django_settings_override_values:
+                for config_key, config_value in django_settings_override_values.items():
+                    setattr(settings, config_key, config_value)
+            else:
+                logger.warning('Site configuration for site (%s) has no django settings overrides.', current_site)
+
+        else:
+            logger.warning('Site configuration for site (%s) has no values set.', current_site)

--- a/openedx/features/edly/tests/factories.py
+++ b/openedx/features/edly/tests/factories.py
@@ -8,6 +8,7 @@ from factory import SelfAttribute, Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from organizations.tests.factories import OrganizationFactory
 
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.features.edly.models import EdlyOrganization, EdlySubOrganization, EdlyUserProfile
 from student.tests.factories import UserFactory
 
@@ -23,19 +24,6 @@ class EdlyOrganizationFactory(DjangoModelFactory):
 
     name = Sequence('Edly Organization {}'.format)
     slug = Sequence('edly-organization-{}'.format)
-
-
-class SiteFactory(DjangoModelFactory):
-    """
-    Factory class for "Site" model.
-    """
-
-    class Meta(object):
-        model = Site
-        django_get_or_create = ('domain',)
-
-    domain = Sequence('{}.testserver.fake'.format)
-    name = SelfAttribute('domain')
 
 
 class EdlySubOrganizationFactory(DjangoModelFactory):

--- a/openedx/features/edly/tests/test_middleware.py
+++ b/openedx/features/edly/tests/test_middleware.py
@@ -6,11 +6,15 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.client import Client, RequestFactory
 
+from openedx.core.djangoapps.site_configuration.models import logger as site_configuration_logger
+from openedx.core.djangoapps.site_configuration.tests.factories import (
+    SiteConfigurationFactory,
+    SiteFactory
+)
 from openedx.features.edly import cookies
 from openedx.features.edly.tests.factories import (
     EdlySubOrganizationFactory,
-    EdlyUserFactory,
-    SiteFactory,
+    EdlyUserFactory
 )
 
 LOGGER_NAME = 'openedx.features.edly.middleware'
@@ -71,3 +75,137 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
 
         response = client.get('/', follow=True)
         assert response.status_code == 200
+
+
+class SettingsOverrideMiddlewareTests(TestCase):
+    """
+    Tests settings override middleware for sites.
+    """
+    def setUp(self):
+        """
+        Create environment for settings override middleware tests.
+        """
+        self.user = EdlyUserFactory()
+        self.request = RequestFactory().get('/')
+        self.request.user = self.user
+        self.request.site = SiteFactory()
+        EdlySubOrganizationFactory(lms_site=self.request.site)
+
+        self.client = Client(SERVER_NAME=self.request.site.domain)
+        self.client.cookies.load(
+            {
+                settings.EDLY_USER_INFO_COOKIE_NAME: cookies._get_edly_user_info_cookie_string(self.request)
+            }
+        )
+        self.client.login(username=self.user.username, password='test')
+        self.default_settings = {key: getattr(settings, key, None) for key in [
+                'SITE_NAME', 'CMS_BASE', 'LMS_BASE', 'LMS_ROOT_URL', 'SESSION_COOKIE_DOMAIN',
+                'LOGIN_REDIRECT_WHITELIST', 'DEFAULT_FEEDBACK_EMAIL', 'CREDENTIALS_PUBLIC_SERVICE_URL'
+            ]
+        }
+
+    def _assert_settings_values(self, expected_settings_values):
+        """
+        Checks if current settings values match expected settings values.
+        """
+        for config_key, expected_config_value in expected_settings_values.items():
+            assert expected_config_value == getattr(settings, config_key, None)
+
+
+    def test_settings_override_middleware_logs_warning_if_no_site_configuration_is_present(self):
+        """
+        Tests "SettingsOverrideMiddleware" logs warning if no site configuration is present.
+        """
+        with LogCapture(LOGGER_NAME) as logger:
+            self.client.get('/', follow=True)
+            logger.check_present(
+                (
+                    LOGGER_NAME,
+                    'WARNING',
+                    'Site ({site}) has no related site configuration.'.format(site=self.request.site)
+                )
+            )
+            self._assert_settings_values(self.default_settings)
+
+    def test_settings_override_middleware_logs_warning_if_site_configuration_has_no_values_set(self):
+        """
+        Tests "SettingsOverrideMiddleware" logs warning if site configuration has no values.
+        """
+        SiteConfigurationFactory(site=self.request.site)
+        with LogCapture(LOGGER_NAME) as logger:
+            self.client.get('/', follow=True)
+            logger.check_present(
+                (
+                    LOGGER_NAME,
+                    'WARNING',
+                    'Site configuration for site ({site}) has no values set.'.format(site=self.request.site)
+                )
+            )
+            self._assert_settings_values(self.default_settings)
+
+    def test_settings_override_middleware_logs_warning_if_site_configuration_is_disabled(self):
+        """
+        Tests "SettingsOverrideMiddleware" logs warning if site configuration is disabled.
+        """
+        SiteConfigurationFactory(
+            site=self.request.site,
+            enabled=False,
+            values={
+                'MARKETING_SITE_ROOT': 'http://wordpress.edx.devstack.lms',
+            }
+        )
+        with LogCapture(site_configuration_logger.name) as logger:
+            self.client.get('/', follow=True)
+            logger.check_present(
+                (
+                    site_configuration_logger.name,
+                    'INFO',
+                    'Site Configuration is not enabled for site ({site}).'.format(site=self.request.site)
+                )
+            )
+            self._assert_settings_values(self.default_settings)
+
+    def test_settings_override_middleware_logs_warning_for_empty_override(self):
+        """
+        Tests "SettingsOverrideMiddleware" logs warning if site configuration has no django settings override values.
+        """
+        SiteConfigurationFactory(
+            site=self.request.site,
+            values={
+                'MARKETING_SITE_ROOT': 'http://wordpress.edx.devstack.lms',
+            }
+        )
+        with LogCapture(LOGGER_NAME) as logger:
+            self.client.get('/', follow=True)
+            logger.check_present(
+                (
+                    LOGGER_NAME,
+                    'WARNING',
+                    'Site configuration for site ({site}) has no django settings overrides.'.format(site=self.request.site)
+                )
+            )
+            self._assert_settings_values(self.default_settings)
+
+    def test_settings_override_middleware_overrides_settings_correctly(self):
+        """
+        Tests "SettingsOverrideMiddleware" correctly overrides django settings.
+        """
+        django_override_settings = {
+            'SITE_NAME': 'Test site',
+            'CMS_BASE': 'localhost:8010',
+            'LMS_BASE': 'localhost:8000',
+            'LMS_ROOT_URL': 'http://edx.devstack.lms',
+            'SESSION_COOKIE_DOMAIN': '.edx.devstack.lms',
+            'LOGIN_REDIRECT_WHITELIST': [],
+            'DEFAULT_FEEDBACK_EMAIL': 'test@example.com',
+            'CREDENTIALS_PUBLIC_SERVICE_URL': 'http://credentials.edx.devstack.lms'
+        }
+        SiteConfigurationFactory(
+            site=self.request.site,
+            values={
+                'DJANGO_SETTINGS_OVERRIDE': django_override_settings
+            }
+        )
+        self._assert_settings_values(self.default_settings)
+        self.client.get('/', follow=True)
+        self._assert_settings_values(django_override_settings)


### PR DESCRIPTION
**Description:**
This PR adds the following things:
- Adds a middleware that overrides settings if  `DJANGO_SETTINGS_OVERRIDE` values are present in the site configuration
- Adds tests for it
- Removes unnecessary classes
- Adds middleware to both LMS and Studio

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1334