### PR TITLE
EDLY_1345 Restrict user's login to only linked edly site

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -36,6 +36,8 @@ from third_party_auth import pipeline, provider
 from util.json_request import JsonResponse
 from util.password_policy_validators import normalize_password
 
+from openedx.features.edly.validators import is_edly_user_allowed_to_login
+
 log = logging.getLogger("edx.student")
 AUDIT_LOG = logging.getLogger("audit")
 
@@ -349,6 +351,9 @@ def login_user(request):
         _check_excessive_login_attempts(user)
 
         possibly_authenticated_user = user
+
+        if not is_edly_user_allowed_to_login(request, possibly_authenticated_user):
+            raise AuthFailedError(_('You are not allowed to login on this site.'))
 
         if not is_user_third_party_authenticated:
             possibly_authenticated_user = _authenticate_first_party(request, user)

--- a/openedx/features/edly/tests/test_validators.py
+++ b/openedx/features/edly/tests/test_validators.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for Validators.
+"""
+from django.test import TestCase
+from django.test.client import RequestFactory
+from student.tests.factories import UserFactory
+
+from openedx.features.edly.tests.factories import (
+    EdlySubOrganizationFactory,
+    EdlyUserProfileFactory,
+    SiteFactory
+)
+from openedx.features.edly.validators import is_edly_user_allowed_to_login
+
+
+class EdlyValidatorsTests(TestCase):
+
+    def setUp(self):
+        self.user = UserFactory.create()
+        self.request = RequestFactory().get('/login')
+        self.request.site = SiteFactory()
+
+        self.edly_user_profile = EdlyUserProfileFactory(user=self.user)
+
+    def test_user_with_edly_sub_organization_access_of_current_site(self):
+        """
+        Test user has access to current site as it's edly sub organization
+        is linked with user's "EdlyUserProfile".
+        """
+
+        edly_sub_organization = EdlySubOrganizationFactory(lms_site=self.request.site)
+        self.edly_user_profile.edly_sub_organizations.add(edly_sub_organization)
+        has_access = is_edly_user_allowed_to_login(self.request, self.user)
+
+        assert has_access
+
+    def test_user_without_edly_sub_organization_access_for_current_site(self):
+        """
+        Test user has no access to current site as it's edly sub organization
+        is not linked with user's "EdlyUserProfile".
+        """
+
+        EdlySubOrganizationFactory(lms_site=self.request.site)
+        has_access = is_edly_user_allowed_to_login(self.request, self.user)
+
+        assert not has_access

--- a/openedx/features/edly/validators.py
+++ b/openedx/features/edly/validators.py
@@ -1,0 +1,44 @@
+from logging import getLogger
+
+from openedx.features.edly.models import (
+    EdlySubOrganization,
+    EdlyUserProfile
+)
+
+logger = getLogger(__name__)
+
+
+def is_edly_user_allowed_to_login(request, possibly_authenticated_user):
+    """
+    Check if the user is allowed to login on the current site.
+
+    This method checks if the user has edly sub organization of current
+    site in it's edly sub organizations list.
+
+    Arguments:
+        request (object): HTTP request object
+        possibly_authenticated_user (User): User object trying to authenticate
+
+    Returns:
+        bool: Returns True if User has Edly Sub Organization Access Otherwise False.
+    """
+
+    if possibly_authenticated_user.is_superuser:
+        return True
+
+    try:
+        edly_sub_org = request.site.edly_sub_org_for_lms
+    except EdlySubOrganization.DoesNotExist:
+        logger.error('Edly sub organization does not exist for site %s.' % request.site)
+        return False
+
+    try:
+        edly_user_profile = possibly_authenticated_user.edly_profile
+    except EdlyUserProfile.DoesNotExist:
+        logger.warning('User %s has no edly profile for site %s.' % (possibly_authenticated_user.email, request.site))
+        return False
+
+    if edly_sub_org.slug in edly_user_profile.get_linked_edly_sub_organizations:
+        return True
+
+    return False


### PR DESCRIPTION
**Description:** Restricted user's login to only linked edly site.
<img width="567" alt="Screenshot 2020-05-21 at 6 03 30 PM" src="https://user-images.githubusercontent.com/15142776/82561819-7858c900-9b8d-11ea-9094-c34ce2b2d204.png">


**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1345

**Testing instructions:**

Try to log in on the red organization with blue user.
**Note: Superuser has access to all sites.**

Run tests:
paver test_system -s lms -t /edx/app/edxapp/edx-platform/openedx/features/edly/tests/test_validators.py
