### PR TITLE
Fixes incorrect activation link domain in post registration email

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -186,7 +186,7 @@ def index(request, extra_context=None, user=AnonymousUser()):
     return render_to_response('index.html', context)
 
 
-def compose_and_send_activation_email(user, profile, user_registration=None):
+def compose_and_send_activation_email(user, profile, user_registration=None, request=None):
     """
     Construct all the required params and send the activation email
     through celery task
@@ -203,7 +203,7 @@ def compose_and_send_activation_email(user, profile, user_registration=None):
     subject = render_to_string('emails/activation_email_subject.txt', context)
     # Email subject *must not* contain newlines
     subject = ''.join(subject.splitlines())
-    message_for_activation = render_to_string('emails/activation_email.txt', context)
+    message_for_activation = render_to_string('emails/activation_email.txt', context, request)
     from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS', from_address)
     if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -179,7 +179,7 @@ def create_account_with_params(request, params):
     if skip_email:
         registration.activate()
     else:
-        compose_and_send_activation_email(user, profile, registration)
+        compose_and_send_activation_email(user, profile, registration, request)
 
     # Perform operations that are non-critical parts of account creation
     create_or_set_user_attribute_created_on_site(user, request.site)


### PR DESCRIPTION
**Description:**
Multisite was putting `dev.multisitesdev.edly.io` which is the root site in the activation link domain in account activation email. This fixes that so that correct link of the site is used when a user signs up on a particular site