### PR TITLE
Certificate preview show "Your Platform Name Here" text

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -571,6 +571,7 @@ def render_html_view(request, user_id, course_id):
 
         _update_context_with_basic_info(context, course_id, platform_name, configuration)
 
+        context['platform_name'] = platform_name
         context['certificate_data'] = active_configuration
 
         # Append/Override the existing view context values with any mode-specific ConfigurationModel values


### PR DESCRIPTION
**Description:**  This PR resolve issue in the certificate preview page, where Instead of showing the platform name, studio shows the `Your Platform Name Here` text. The updated value for `platform_name` based on Site Configuration was missing from the context of Certificates and we were receiving default value in it. 

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1398

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
<img width="1327" alt="Screenshot 2020-06-03 at 3 01 06 PM" src="https://user-images.githubusercontent.com/17013371/83623704-1ba4d780-a5ab-11ea-9f64-d8316bec0966.png">
