### PR TITLE
Fix: Loggedin cookie not deleted when user loggedout via middleware

### DIFF
--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -29,8 +29,8 @@ class EdlyOrganizationAccessMiddleware(object):
         user_is_superuser = request.user.is_superuser
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
-            logout(request)
-            return HttpResponseRedirect(reverse('logout'))
+            if request.path != '/logout':
+                return HttpResponseRedirect(reverse('logout'))
 
 
 class SettingsOverrideMiddleware(object):


### PR DESCRIPTION
**Description:**
This PR fixed the bug where the cookies were not deleted when the user is logged out via the middleware. 

Before this, we explicitly call the `logout` function before calling to logout view. Due to this the `dispatch` function of view didn't trigger.  