### PR TITLE
Hitting red site url while signed in on blue site leads to logout url of red site

### DIFF
--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -30,7 +30,7 @@ class EdlyOrganizationAccessMiddleware(object):
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
             if request.path != '/logout':
-                return HttpResponseRedirect(reverse('logout'))
+                return HttpResponseRedirect(settings.FRONTEND_LOGOUT_URL)
 
 
 class SettingsOverrideMiddleware(object):

--- a/openedx/features/edly/tests/test_middleware.py
+++ b/openedx/features/edly/tests/test_middleware.py
@@ -65,7 +65,7 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
             response = self.client.get('/', follow=True)
             self.assertRedirects(
                 response,
-                '/logout',
+                settings.FRONTEND_LOGOUT_URL,
                 status_code=302,
                 target_status_code=200,
                 fetch_redirect_response=True


### PR DESCRIPTION
Description:
Used LMS URL of the current site to attempt logout.

JIRA:
https://edlyio.atlassian.net/browse/EDLY-1414

Testing instruction:
Sign in to Red Site, try to hit Blue site URL. It should first log out you on the Red site before going to the login of Blue site.