### PR TITLE
Used current request url to logout from current site & redirect to requested site

### DIFF
--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.features.edly.utils import user_has_edly_organization_access
@@ -28,7 +29,7 @@ class EdlyOrganizationAccessMiddleware(object):
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
             if request.path != '/logout':
-                return HttpResponseRedirect(settings.FRONTEND_LOGOUT_URL)
+                return HttpResponseRedirect(reverse('logout'))
 
 
 class SettingsOverrideMiddleware(object):

--- a/openedx/features/edly/tests/test_middleware.py
+++ b/openedx/features/edly/tests/test_middleware.py
@@ -65,7 +65,7 @@ class EdlyOrganizationAccessMiddlewareTests(TestCase):
             response = self.client.get('/', follow=True)
             self.assertRedirects(
                 response,
-                settings.FRONTEND_LOGOUT_URL,
+                '/logout',
                 status_code=302,
                 target_status_code=200,
                 fetch_redirect_response=True


### PR DESCRIPTION
Description:
Used requested site URL to attempt logout.

This PR actually reverts previous changes done in this PR (https://github.com/edly-io/edx-platform/pull/97)

Related PR in e-commerce (https://github.com/edly-io/ecommerce/pull/24)

JIRA:
https://edlyio.atlassian.net/browse/EDLY-1414

Related PR in LMS/Studio: edly-io/edx-platform#97

Testing instruction:
Sign in to Red Site, try to hit Blue site URL. It should first log out you and redirect to the login of Blue site.