### PR TITLE
Added frontend logout url logic too to ensure safe logout on studio

### DIFF
--- a/openedx/features/edly/middleware.py
+++ b/openedx/features/edly/middleware.py
@@ -29,7 +29,11 @@ class EdlyOrganizationAccessMiddleware(object):
         if user_is_authenticated and not user_is_superuser and not user_has_edly_organization_access(request):
             logger.exception('Edly user %s has no access for site %s.' % (request.user.email, request.site))
             if request.path != '/logout':
-                return HttpResponseRedirect(reverse('logout'))
+                logout_url = getattr(settings, 'FRONTEND_LOGOUT_URL', None)
+                if logout_url:
+                    return HttpResponseRedirect(logout_url)
+                else:
+                    return HttpResponseRedirect(reverse('logout'))
 
 
 class SettingsOverrideMiddleware(object):


### PR DESCRIPTION
Description:
Used requested site URL to attempt logout.

**The reason for adding frontend_logout_url again is that when on studio it reverse to url like studio…/logout where we need lms../logout.**

Relevant PRs
https://github.com/edly-io/edx-platform/pull/97
https://github.com/edly-io/edx-platform/pull/100

Related PR in e-commerce (https://github.com/edly-io/edx-platform/pull/97)

JIRA:
https://edlyio.atlassian.net/browse/EDLY-1414

Testing instruction:
Sign in to Red Site, try to hit Blue site URL. It should first log out you and redirect to the login of Blue site.