### PR TITLE
Adds global staff creator role, updates course creator manage method

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -14,6 +14,7 @@ from student.roles import (
     CourseCreatorRole,
     CourseInstructorRole,
     CourseRole,
+    GlobalCourseCreatorRole,
     CourseStaffRole,
     GlobalStaff,
     LibraryUserRole,
@@ -87,6 +88,8 @@ def get_user_permissions(user, course_key, org=None):
     if GlobalStaff().has_user(user) or OrgInstructorRole(org=org).has_user(user):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
+        return all_perms
+    if course_key and user_has_role(user, GlobalCourseCreatorRole(org)):
         return all_perms
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
@@ -167,7 +170,7 @@ def _check_caller_authority(caller, role):
     if not (caller.is_authenticated and caller.is_active):
         raise PermissionDenied
     # superuser
-    if GlobalStaff().has_user(caller):
+    if GlobalStaff().has_user(caller) or GlobalCourseCreatorRole().has_user(caller):
         return
 
     if isinstance(role, (GlobalStaff, CourseCreatorRole)):

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -247,6 +247,23 @@ class OrgRole(RoleBase):
 
 
 @register_access_role
+class GlobalCourseCreatorRole(OrgRole):
+    """
+    A global course creator with access to all courses of the current site.
+    """
+    ROLE = 'global_course_creator'
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialization method for GlobalCourseCreatorRole.
+
+        Arguments:
+            org (str): Name of the organization of GlobalCourseCreatorRole
+        """
+        super(GlobalCourseCreatorRole, self).__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
 class CourseStaffRole(CourseRole):
     """A Staff member of a course"""
     ROLE = 'staff'


### PR DESCRIPTION
**Description:**
This PR adds the following:
- Adds a `GlobalStaffCreatorRole`
- Updates `update_course_creator_status` method to set status of course creator as `unrequested` and remove all `CourseStaffRole` and `CourseInstructorRole` entries
- Adds a `set_global_course_creator_status` method to manage `GlobalCourseCreator`
- Adds tests

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1445