### PR TITLE
Adds edly cookie set method for social auth

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -34,7 +34,6 @@ from openedx.core.djangoapps.user_api.serializers import CountryTimeZoneSerializ
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.views.register import create_account_with_params
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
-from openedx.features.edly.cookies import set_logged_in_edly_cookies
 from openedx.features.edly.utils import create_user_link_with_edly_sub_organization
 from student.helpers import AccountValidationError
 from util.json_request import JsonResponse
@@ -174,7 +173,6 @@ class RegistrationView(APIView):
 
         response = JsonResponse({"success": True})
         set_logged_in_cookies(request, response, user)
-        set_logged_in_edly_cookies(request, response, user)
         return response
 
     @method_decorator(transaction.non_atomic_requests)

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -22,6 +22,7 @@ from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token, 
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_from_token
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
+from openedx.features.edly.cookies import set_logged_in_edly_cookies
 from student.models import CourseEnrollment
 
 
@@ -146,6 +147,7 @@ def set_logged_in_cookies(request, response, user):
         _set_deprecated_logged_in_cookie(response, cookie_settings)
         _set_deprecated_user_info_cookie(response, request, user, cookie_settings)
         _create_and_set_jwt_cookies(response, request, cookie_settings, user=user)
+        set_logged_in_edly_cookies(request, response, user, cookie_settings)
         CREATE_LOGON_COOKIE.send(sender=None, user=user, response=response)
 
     return response

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -26,7 +26,6 @@ from openedx.core.djangoapps.password_policy import compliance as password_polic
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.features.edly.cookies import set_logged_in_edly_cookies
 from student.models import LoginFailures
 from student.views import send_reactivation_email_for_user
 from student.forms import send_password_reset_email_for_user
@@ -378,7 +377,6 @@ def login_user(request):
 
         # Ensure that the external marketing site can
         # detect that the user is logged in.
-        set_logged_in_edly_cookies(request, response, possibly_authenticated_user)
         return set_logged_in_cookies(request, response, possibly_authenticated_user)
     except AuthFailedError as error:
         log.exception(error.get_response())

--- a/openedx/features/edly/cookies.py
+++ b/openedx/features/edly/cookies.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 
-from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.features.edly.models import EdlySubOrganization
 from openedx.features.edly.utils import encode_edly_user_info_cookie
 from student import auth
 from student.roles import CourseCreatorRole
 
 
-def set_logged_in_edly_cookies(request, response, user):
+def set_logged_in_edly_cookies(request, response, user, cookie_settings):
     """
     Set cookies for edly users at the time of login.
 
@@ -22,7 +21,6 @@ def set_logged_in_edly_cookies(request, response, user):
 
     """
     if user.is_authenticated and not user.is_anonymous:
-        cookie_settings = standard_cookie_settings(request)
         edly_cookie_string = _get_edly_user_info_cookie_string(request)
 
         response.set_cookie(

--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
+from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings as cookie_settings
 from openedx.core.djangolib.testing.utils import skip_unless_cms
 from openedx.features.edly import cookies as cookies_api
 from openedx.features.edly.tests.factories import EdlySubOrganizationFactory, EdlyUserProfileFactory, SiteFactory
@@ -114,7 +115,11 @@ class UtilsTests(TestCase):
         Test user have access to a valid site URL which is linked to that user.
         """
         self._create_edly_sub_organization()
-        response = cookies_api.set_logged_in_edly_cookies(self.request, HttpResponse(), self.user)
+        response = cookies_api.set_logged_in_edly_cookies(
+            self.request, HttpResponse(),
+            self.user,
+            cookie_settings(self.request)
+        )
         self._copy_cookies_to_request(response, self.request)
 
         user_has_access = user_has_edly_organization_access(self.request)


### PR DESCRIPTION
**Description:**
Social auth login calls django's native `login()` method instead of the login view. That's why we need to set `edly-user-info` cookie in the pipeline `set_logged_in_cookies` method. This PR adds that change.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1474