### PR TITLE
Moves delete_logged_in_edly_cookies method to delete_logged_in_cookies

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -22,7 +22,7 @@ from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token, 
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_from_token
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
-from openedx.features.edly.cookies import set_logged_in_edly_cookies
+from openedx.features.edly.cookies import delete_logged_in_edly_cookies, set_logged_in_edly_cookies
 from student.models import CourseEnrollment
 
 
@@ -83,6 +83,8 @@ def delete_logged_in_cookies(response):
             path='/',
             domain=settings.SESSION_COOKIE_DOMAIN
         )
+
+    delete_logged_in_edly_cookies(response)
 
     return response
 

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -11,7 +11,6 @@ from django.views.generic import TemplateView
 from provider.oauth2.models import Client
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
-from openedx.features.edly.cookies import delete_logged_in_edly_cookies
 
 
 class LogoutView(TemplateView):
@@ -66,7 +65,6 @@ class LogoutView(TemplateView):
 
         # Clear the cookie used by the edx.org marketing site
         delete_logged_in_cookies(response)
-        delete_logged_in_edly_cookies(response)
 
         return response
 


### PR DESCRIPTION
**Description:**
Moved `delete_logged_in_edly_cookies` to `delete_logged_in_cookies` method so `edly-user-info` cookie always gets deleted on logout.