### PR TITLE
use eventtracking in place of track

### DIFF
--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -22,7 +22,7 @@ class LegacyFieldMappingProcessor(object):
     def __call__(self, event):
         context = event.get('context', {})
         if 'context' in event:
-            delete_from_context = True if context.get('event_source', '') != 'task' else False
+            delete_from_context = bool(context.get('event_source', '') != 'task')
             for field in CONTEXT_FIELDS_TO_INCLUDE:
                 self.move_from_context(field, event, delete_from_context=delete_from_context)
             if delete_from_context:

--- a/common/djangoapps/track/shim.py
+++ b/common/djangoapps/track/shim.py
@@ -22,11 +22,9 @@ class LegacyFieldMappingProcessor(object):
     def __call__(self, event):
         context = event.get('context', {})
         if 'context' in event:
-            delete_from_context = bool(context.get('event_source', '') != 'task')
             for field in CONTEXT_FIELDS_TO_INCLUDE:
-                self.move_from_context(field, event, delete_from_context=delete_from_context)
-            if delete_from_context:
-                remove_shim_context(event)
+                self.move_from_context(field, event)
+            remove_shim_context(event)
 
         if 'data' in event:
             if context.get('event_source', '') == 'browser' and isinstance(event['data'], dict):
@@ -50,13 +48,12 @@ class LegacyFieldMappingProcessor(object):
         self.move_from_context('event_source', event, 'server')
         self.move_from_context('page', event, None)
 
-    def move_from_context(self, field, event, default_value='', delete_from_context=True):
+    def move_from_context(self, field, event, default_value=''):
         """Move a field from the context to the top level of the event."""
         context = event.get('context', {})
         if field in context:
             event[field] = context[field]
-            if delete_from_context:
-                del context[field]
+            del context[field]
         else:
             event[field] = default_value
 

--- a/common/djangoapps/track/tracker.py
+++ b/common/djangoapps/track/tracker.py
@@ -21,7 +21,6 @@ below::
 
 
 import inspect
-import logging
 import warnings
 from importlib import import_module
 
@@ -34,7 +33,6 @@ __all__ = ['send']
 
 
 backends = {}
-LOGGER = logging.getLogger(__name__)
 
 
 def _initialize_backends_from_django_settings():

--- a/common/djangoapps/track/tracker.py
+++ b/common/djangoapps/track/tracker.py
@@ -20,6 +20,7 @@ below::
 
 
 import inspect
+import logging
 from importlib import import_module
 
 import six
@@ -31,6 +32,7 @@ __all__ = ['send']
 
 
 backends = {}
+LOGGER = logging.getLogger(__name__)
 
 
 def _initialize_backends_from_django_settings():
@@ -87,7 +89,9 @@ def send(event):
     Send an event object to all the initialized backends.
 
     """
-
+    LOGGER.warning(
+        'Tracker is deprecated. Please use eventtracking to generate tracking logs.'
+    )
     for name, backend in six.iteritems(backends):
         backend.send(event)
 

--- a/common/djangoapps/track/tracker.py
+++ b/common/djangoapps/track/tracker.py
@@ -1,4 +1,5 @@
 """
+WARNING! track.tracker module is deprecated please use eventtracking app to track events
 Module that tracks analytics events by sending them to different
 configurable backends.
 
@@ -21,6 +22,7 @@ below::
 
 import inspect
 import logging
+import warnings
 from importlib import import_module
 
 import six
@@ -89,8 +91,8 @@ def send(event):
     Send an event object to all the initialized backends.
 
     """
-    LOGGER.warning(
-        'Tracker is deprecated. Please use eventtracking to generate tracking logs.'
+    warnings.warn(
+        'track.tracker module is deprecated. Please use eventtracking to send events.', DeprecationWarning
     )
     for name, backend in six.iteritems(backends):
         backend.send(event)

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from eventtracking import tracker as eventtracker
 from ipware.ip import get_ip
 
-from track import contexts, shim
+from track import contexts, shim, tracker
 
 
 def _get_request_header(request, header_name, default=''):

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -17,11 +17,6 @@ from edxmako.shortcuts import render_to_response
 from track import contexts, shim, tracker
 
 
-def log_event(event):
-    """Capture a event by sending it to the register trackers"""
-    tracker.send(event)
-
-
 def _get_request_header(request, header_name, default=''):
     """Helper method to get header values from a request's META dict, if present."""
     if request is not None and hasattr(request, 'META') and header_name in request.META:
@@ -46,6 +41,18 @@ def _get_request_value(request, value_name, default=''):
         elif request.method == 'POST':
             return request.POST.get(value_name, default)
     return default
+
+
+def _get_course_context(page):
+    """Return the course context from the provided page.
+
+    If the context has no/empty course_id, return empty context
+    """
+    course_context = contexts.course_context_from_url(page)
+    if course_context.get('course_id', '') == '':
+        course_context = {}
+
+    return course_context
 
 
 def _add_user_id_for_username(data):
@@ -111,27 +118,16 @@ def server_track(request, event_type, event, page=None):
     except:
         username = "anonymous"
 
-    # define output:
-    event = {
-        "username": username,
-        "ip": _get_request_ip(request),
-        "referer": _get_request_header(request, 'HTTP_REFERER'),
-        "accept_language": _get_request_header(request, 'HTTP_ACCEPT_LANGUAGE'),
-        "event_source": "server",
-        "event_type": event_type,
-        "event": event,
-        "agent": _get_request_header(request, 'HTTP_USER_AGENT').encode().decode('latin1'),
-        "page": page,
-        "time": datetime.datetime.utcnow().replace(tzinfo=pytz.utc),
-        "host": _get_request_header(request, 'SERVER_NAME'),
-        "context": eventtracker.get_tracker().resolve_context(),
-    }
+    context_override = _get_course_context(page)
+    context_override.update({
+        'username': username,
+        'event_source': 'server',
+        'page': page
+    })
 
-    # Some duplicated fields are passed into event-tracking via the context by track.middleware.
-    # Remove them from the event here since they are captured elsewhere.
-    shim.remove_shim_context(event)
-
-    log_event(event)
+    event_tracker = eventtracker.get_tracker()
+    with event_tracker.context('edx.course.server', context_override):
+        eventtracker.emit(name=event_type, data=event)
 
 
 def task_track(request_info, task_info, event_type, event, page=None):
@@ -156,22 +152,14 @@ def task_track(request_info, task_info, event_type, event, page=None):
 
     # supplement event information with additional information
     # about the task in which it is running.
-    full_event = dict(event, **task_info)
+    data = dict(event, **task_info)
 
-    # Get values from the task-level
-    # information, or just add placeholder values.
-    with eventtracker.get_tracker().context('edx.course.task', contexts.course_context_from_url(page)):
-        event = {
-            "username": request_info.get('username', 'unknown'),
-            "ip": request_info.get('ip', 'unknown'),
-            "event_source": "task",
-            "event_type": event_type,
-            "event": full_event,
-            "agent": request_info.get('agent', 'unknown'),
-            "page": page,
-            "time": datetime.datetime.utcnow().replace(tzinfo=pytz.utc),
-            "host": request_info.get('host', 'unknown'),
-            "context": eventtracker.get_tracker().resolve_context(),
-        }
+    context_override = _get_course_context(page)
+    context_override.update({
+        'username': request_info.get('username', 'unknown'),
+        'event_source': 'task',
+        'page': page,
+    })
 
-    log_event(event)
+    with eventtracker.get_tracker().context('edx.course.task', context_override):
+        eventtracker.emit(name=event_type, data=data)

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -1,20 +1,14 @@
 
 
-import datetime
 import json
-
-import pytz
 import six
-from django.contrib.auth.decorators import login_required
+
 from django.contrib.auth.models import User
 from django.http import HttpResponse
-from django.shortcuts import redirect
-from django.views.decorators.csrf import ensure_csrf_cookie
 from eventtracking import tracker as eventtracker
 from ipware.ip import get_ip
 
-from edxmako.shortcuts import render_to_response
-from track import contexts, shim, tracker
+from track import contexts, shim
 
 
 def _get_request_header(request, header_name, default=''):
@@ -157,6 +151,9 @@ def task_track(request_info, task_info, event_type, event, page=None):
     context_override = _get_course_context(page)
     context_override.update({
         'username': request_info.get('username', 'unknown'),
+        'ip': request_info.get('ip', 'unknown'),
+        'agent': request_info.get('agent', 'unknown'),
+        'host': request_info.get('host', 'unknown'),
         'event_source': 'task',
         'page': page,
     })

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -148,7 +148,7 @@ def task_track(request_info, task_info, event_type, event, page=None):
     # about the task in which it is running.
     data = dict(event, **task_info)
 
-    context_override = _get_course_context(page)
+    context_override = contexts.course_context_from_url(page)
     context_override.update({
         'username': request_info.get('username', 'unknown'),
         'ip': request_info.get('ip', 'unknown'),

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -266,7 +266,8 @@ class TestTrackViews(EventTrackingTestCase):
                 'name': self.path_with_course,
                 'context': {
                     'username': 'anonymous',
-                    'user_id': '', 'accept_language': '',
+                    'user_id': '',
+                    'accept_language': '',
                     'ip': '127.0.0.1',
                     'org_id': 'foo',
                     'agent': '',
@@ -329,6 +330,9 @@ class TestTrackViews(EventTrackingTestCase):
             'name': str(sentinel.event_type),
             'context': {
                 'username': 'anonymous',
+                'ip': '127.0.0.1',
+                'agent': 'agent',
+                'host': 'testserver',
                 'page': None,
                 'event_source': 'task'
             }

--- a/common/djangoapps/track/views/tests/test_views.py
+++ b/common/djangoapps/track/views/tests/test_views.py
@@ -28,6 +28,7 @@ class TestTrackViews(EventTrackingTestCase):
         self.request_factory = RequestFactory()
 
         patcher = patch('track.views.tracker', autospec=True)
+
         self.mock_tracker = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -195,24 +196,18 @@ class TestTrackViews(EventTrackingTestCase):
         views.server_track(request, str(sentinel.event_type), '{}')
 
         expected_event = {
-            'accept_language': '',
-            'referer': '',
-            'username': 'anonymous',
-            'ip': '127.0.0.1',
-            'event_source': 'server',
-            'event_type': str(sentinel.event_type),
-            'event': '{}',
-            'agent': '',
-            'page': None,
-            'time': FROZEN_TIME,
-            'host': 'testserver',
-            'context': {},
+            'timestamp': FROZEN_TIME,
+            'data': '{}',
+            'name': str(sentinel.event_type),
+            'context':
+            {
+                'username': 'anonymous',
+                'page': None,
+                'event_source': 'server'
+            }
         }
-        self.assert_mock_tracker_call_matches(expected_event)
 
-    def assert_mock_tracker_call_matches(self, expected_event):
-        self.assertEqual(len(self.mock_tracker.send.mock_calls), 1)
-        actual_event = self.mock_tracker.send.mock_calls[0][1][0]
+        actual_event = self.get_event()
         assert_event_matches(expected_event, actual_event)
 
     def test_server_track_with_middleware(self):
@@ -225,28 +220,35 @@ class TestTrackViews(EventTrackingTestCase):
             views.server_track(request, str(sentinel.event_type), '{}')
 
             expected_event = {
-                'accept_language': '',
-                'referer': '',
-                'username': 'anonymous',
-                'ip': '127.0.0.1',
-                'event_source': 'server',
-                'event_type': str(sentinel.event_type),
-                'event': '{}',
-                'agent': '',
-                'page': None,
-                'time': FROZEN_TIME,
-                'host': 'testserver',
+                'timestamp': FROZEN_TIME,
+                'data': '{"GET": {}, "POST": {}}',
+                'name': self.path_with_course,
                 'context': {
+                    'username': 'anonymous',
                     'user_id': '',
-                    'course_id': u'foo/bar/baz',
+                    'accept_language': '',
+                    'ip': '127.0.0.1',
                     'org_id': 'foo',
-                    'path': u'/courses/foo/bar/baz/xmod/'
-                },
+                    'agent': '',
+                    'event_source': 'server',
+                    'host': 'testserver',
+                    'session': '',
+                    'referer': '',
+                    'client_id': None,
+                    'course_id': 'foo/bar/baz',
+                    'path': self.path_with_course,
+                    'page': None
+                }
             }
         finally:
             middleware.process_response(request, None)
 
-        self.assert_mock_tracker_call_matches(expected_event)
+        actual_event = self.get_event()
+        assert_event_matches(
+            expected_event,
+            actual_event,
+            tolerate={'string_payload'}
+        )
 
     def test_server_track_with_middleware_and_google_analytics_cookie(self):
         middleware = TrackMiddleware()
@@ -259,48 +261,49 @@ class TestTrackViews(EventTrackingTestCase):
             views.server_track(request, str(sentinel.event_type), '{}')
 
             expected_event = {
-                'accept_language': '',
-                'referer': '',
-                'username': 'anonymous',
-                'ip': '127.0.0.1',
-                'event_source': 'server',
-                'event_type': str(sentinel.event_type),
-                'event': '{}',
-                'agent': '',
-                'page': None,
-                'time': FROZEN_TIME,
-                'host': 'testserver',
+                'timestamp': FROZEN_TIME,
+                'data': '{"GET": {}, "POST": {}}',
+                'name': self.path_with_course,
                 'context': {
-                    'user_id': '',
-                    'course_id': u'foo/bar/baz',
+                    'username': 'anonymous',
+                    'user_id': '', 'accept_language': '',
+                    'ip': '127.0.0.1',
                     'org_id': 'foo',
-                    'path': u'/courses/foo/bar/baz/xmod/'
-                },
+                    'agent': '',
+                    'event_source': 'server',
+                    'host': 'testserver',
+                    'session': '',
+                    'referer': '',
+                    'client_id': '1033501218.1368477899',
+                    'course_id': 'foo/bar/baz',
+                    'path': self.path_with_course,
+                    'page': None
+                }
             }
+
         finally:
             middleware.process_response(request, None)
 
-        self.assert_mock_tracker_call_matches(expected_event)
+        actual_event = self.get_event()
+        assert_event_matches(expected_event, actual_event, tolerate={'string_payload', })
 
     def test_server_track_with_no_request(self):
         request = None
         views.server_track(request, str(sentinel.event_type), '{}')
 
         expected_event = {
-            'accept_language': '',
-            'referer': '',
-            'username': 'anonymous',
-            'ip': '',
-            'event_source': 'server',
-            'event_type': str(sentinel.event_type),
-            'event': '{}',
-            'agent': '',
-            'page': None,
-            'time': FROZEN_TIME,
-            'host': '',
-            'context': {},
+            'timestamp': FROZEN_TIME,
+            'data': '{}',
+            'name': str(sentinel.event_type),
+            'context': {
+                'username': 'anonymous',
+                'page': None,
+                'event_source':
+                'server'
+            }
         }
-        self.assert_mock_tracker_call_matches(expected_event)
+        actual_event = self.get_event()
+        assert_event_matches(expected_event, actual_event)
 
     def test_task_track(self):
         request_info = {
@@ -321,18 +324,15 @@ class TestTrackViews(EventTrackingTestCase):
         views.task_track(request_info, task_info, str(sentinel.event_type), self.event)
 
         expected_event = {
-            'username': 'anonymous',
-            'ip': '127.0.0.1',
-            'event_source': 'task',
-            'event_type': str(sentinel.event_type),
-            'event': expected_event_data,
-            'agent': 'agent',
-            'page': None,
-            'time': FROZEN_TIME,
-            'host': 'testserver',
+            'timestamp': FROZEN_TIME,
+            'data': expected_event_data,
+            'name': str(sentinel.event_type),
             'context': {
-                'course_id': '',
-                'org_id': ''
-            },
+                'username': 'anonymous',
+                'page': None,
+                'event_source': 'task'
+            }
         }
-        self.assert_mock_tracker_call_matches(expected_event)
+
+        actual_event = self.get_event()
+        assert_event_matches(expected_event, actual_event)

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -1582,7 +1582,13 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
         )
         response = self.client.get(test_url)
         self.assertEqual(response.status_code, 200)
-        actual_event = self.get_event()
+
+        # There are two events being emitted in this flow.
+        # One for page hit (due to the tracker in the middleware) and
+        # one due to the certificate being visited.
+        # We are interested in the second one.
+        actual_event = self.get_event(1)
+
         self.assertEqual(actual_event['name'], 'edx.certificate.evidence_visited')
         assert_event_matches(
             {
@@ -1617,6 +1623,13 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
             }
         )
         response = self.client.get(test_url)
+
+        # There are two events being emitted in this flow.
+        # One for page hit (due to the tracker in the middleware) and
+        # one due to the certificate being visited.
+        # We are interested in the second one.
+        actual_event = self.get_event(1)
+
         self.assertEqual(response.status_code, 200)
         assert_event_matches(
             {
@@ -1635,5 +1648,5 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
                     'enrollment_mode': 'honor',
                 },
             },
-            self.get_event()
+            actual_event
         )

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -997,6 +997,7 @@ class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 @ddt.ddt
 class TestTOC(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
+
     def setup_request_and_course(self, num_finds, num_sends):
         """
         Sets up the toy course in the modulestore and the request object.
@@ -1522,6 +1523,7 @@ class TestHtmlModifiers(ModuleStoreTestCase):
     Tests to verify that standard modifications to the output of XModule/XBlock
     student_view are taking place
     """
+
     def setUp(self):
         super(TestHtmlModifiers, self).setUp()
         self.course = CourseFactory.create()
@@ -1717,6 +1719,7 @@ class DetachedXBlock(XBlock):
     """
     XBlock marked with the 'detached' flag.
     """
+
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         A simple view that returns just enough to test.
@@ -2002,7 +2005,7 @@ class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         )
 
 
-@patch('track.views.tracker', autospec=True)
+@patch('track.views.eventtracker', autospec=True)
 class TestModuleTrackingContext(SharedModuleStoreTestCase):
     """
     Ensure correct tracking information is included in events emitted during XBlock callback handling.
@@ -2054,7 +2057,11 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
             return {'content': 'test1', 'data_field': 'test2'}
 
         AsideTestType.get_event_context = get_event_context
-        context_info = self.handle_callback_and_get_context_info(mock_tracker, problem_display_name)
+
+        # for different operations, there are different number of context calls.
+        # We are sending this `call_idx` to get the mock call that we are interested in.
+        context_info = self.handle_callback_and_get_context_info(mock_tracker, problem_display_name, call_idx=4)
+
         self.assertIn('asides', context_info)
         self.assertIn('test_aside', context_info['asides'])
         self.assertIn('content', context_info['asides']['test_aside'])
@@ -2062,11 +2069,15 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
         self.assertIn('data_field', context_info['asides']['test_aside'])
         self.assertEqual(context_info['asides']['test_aside']['data_field'], 'test2')
 
-    def handle_callback_and_get_context_info(self, mock_tracker, problem_display_name=None):
+    def handle_callback_and_get_context_info(self,
+                                             mock_tracker,
+                                             problem_display_name=None,
+                                             call_idx=0):
         """
         Creates a fake module, invokes the callback and extracts the 'context'
         metadata from the emitted problem_check event.
         """
+
         descriptor_kwargs = {
             'category': 'problem',
             'data': self.problem_xml
@@ -2075,28 +2086,35 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
             descriptor_kwargs['display_name'] = problem_display_name
 
         descriptor = ItemFactory.create(**descriptor_kwargs)
+        with patch('lms.djangoapps.courseware.module_render.tracker') as mock_tracker_for_context:
+            render.handle_xblock_callback(
+                self.request,
+                text_type(self.course.id),
+                quote_slashes(text_type(descriptor.location)),
+                'xmodule_handler',
+                'problem_check',
+            )
 
-        render.handle_xblock_callback(
-            self.request,
-            text_type(self.course.id),
-            quote_slashes(text_type(descriptor.location)),
-            'xmodule_handler',
-            'problem_check',
-        )
+            self.assertEquals(len(mock_tracker.emit.mock_calls), 1)
+            mock_call = mock_tracker.emit.mock_calls[0]
+            event = mock_call[2]
 
-        self.assertEqual(len(mock_tracker.send.mock_calls), 1)
-        mock_call = mock_tracker.send.mock_calls[0]
-        event = mock_call[1][0]
+            self.assertEquals(event['name'], 'problem_check')
 
-        self.assertEqual(event['event_type'], 'problem_check')
-        return event['context']
+            # for different operations, there are different number of context calls.
+            # We are sending this `call_idx` to get the mock call that we are interested in.
+            context = mock_tracker_for_context.get_tracker.mock_calls[call_idx][1][1]
+
+            return context
 
     def handle_callback_and_get_module_info(self, mock_tracker, problem_display_name=None):
         """
         Creates a fake module, invokes the callback and extracts the 'module'
         metadata from the emitted problem_check event.
         """
-        event = self.handle_callback_and_get_context_info(mock_tracker, problem_display_name)
+        event = self.handle_callback_and_get_context_info(
+            mock_tracker, problem_display_name, call_idx=1
+        )
         return event['module']
 
     def test_missing_display_name(self, mock_tracker):
@@ -2194,6 +2212,7 @@ class TestRebindModule(TestSubmittingProblems):
     Tests to verify the functionality of rebinding a module.
     Inherit from TestSubmittingProblems to get functionality that set up a course structure
     """
+
     def setUp(self):
         super(TestRebindModule, self).setUp()
         self.homework = self.add_graded_section_to_course('homework')
@@ -2552,6 +2571,7 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
     """
     Tests that verify disabled XBlock types are not loaded.
     """
+
     def setUp(self):
         super(TestDisabledXBlockTypes, self).setUp()
         XBlockConfiguration(name='video', enabled=False).save()

--- a/lms/envs/devstack_with_worker.py
+++ b/lms/envs/devstack_with_worker.py
@@ -21,7 +21,7 @@ from lms.envs.devstack import *
 
 # Require a separate celery worker
 CELERY_ALWAYS_EAGER = False
-
+BROKER_URL = 'redis://:password@edx.devstack.redis:6379/'
 # Disable transaction management because we are using a worker. Views
 # that request a task and wait for the result will deadlock otherwise.
 for database_name in DATABASES:

--- a/openedx/core/lib/tests/assertions/events.py
+++ b/openedx/core/lib/tests/assertions/events.py
@@ -190,15 +190,16 @@ def block_indent(text, spaces=4):
 
 def parse_event_payload(event):
     """
-    Given an event, parse the "event" field as a JSON string.
+    Given an event, parse the 'event' field, if found otherwise 'data' field as a JSON string.
 
     Note that this may simply return the same event unchanged, or return a new copy of the event with the payload
     parsed. It will never modify the event in place.
     """
-    if 'event' in event and isinstance(event['event'], six.string_types):
+    payload_key = 'event' if 'event' in event else 'data'
+    if payload_key in event and isinstance(event[payload_key], six.string_types):
         event = event.copy()
         try:
-            event['event'] = json.loads(event['event'])
+            event[payload_key] = json.loads(event[payload_key])
         except ValueError:
             pass
     return event


### PR DESCRIPTION
- Deprecate `track`'s `tracker.send` and use `eventtracking`'s `tracker.emit` calls.
- Update unit tests accordingly

