### PR TITLE
Updates permissions for updating Edly staff roles

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -170,7 +170,7 @@ def _check_caller_authority(caller, role):
     if not (caller.is_authenticated and caller.is_active):
         raise PermissionDenied
     # superuser
-    if GlobalStaff().has_user(caller) or GlobalCourseCreatorRole().has_user(caller):
+    if GlobalStaff().has_user(caller) or caller.groups.filter(name=settings.EDLY_PANEL_ADMIN_USERS_GROUP).exists():
         return
 
     if isinstance(role, (GlobalStaff, CourseCreatorRole)):


### PR DESCRIPTION
**Description:**
This PR updates permissions so only global staff and Edly panel admin users can update course creator and global course creator.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-1515