### PR TITLE
Enable Forum Notifications for Threads

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -107,11 +107,7 @@ def _track_notification_sent(message, context):
 
 def _should_send_message(context):
     cc_thread_author = cc.User(id=context['thread_author_id'], course_id=context['course_id'])
-    return (
-        _is_user_subscribed_to_thread(cc_thread_author, context['thread_id']) and
-        _is_not_subcomment(context['comment_id']) and
-        _is_first_comment(context['comment_id'], context['thread_id'])
-    )
+    return _is_user_subscribed_to_thread(cc_thread_author, context['thread_id'])
 
 
 def _is_not_subcomment(comment_id):

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -238,9 +238,9 @@ class TaskTestCase(ModuleStoreTestCase):
             self.assertTrue(self.mock_permalink in rendered_email.body_html)
             self.assertTrue(message.context['site'].domain in rendered_email.body_html)
 
-    def run_should_not_send_email_test(self, thread, comment_dict):
+    def run_should_send_email_test(self, thread, comment_dict):
         """
-        assert email is not sent
+        assert email is sent
         """
         self.mock_request.side_effect = make_mock_responder(
             subscribed_thread_ids=[self.discussion_id],
@@ -251,27 +251,26 @@ class TaskTestCase(ModuleStoreTestCase):
         comment = cc.Comment.find(id=comment_dict['id']).retrieve()
         comment_created.send(sender=None, user=user, post=comment)
 
-        actual_result = _should_send_message({
+        send_message_status = _should_send_message({
             'thread_author_id': self.thread_author.id,
             'course_id': self.course.id,
             'comment_id': comment_dict['id'],
             'thread_id': thread['id'],
         })
-        self.assertEqual(actual_result, False)
-        self.assertFalse(self.mock_ace_send.called)
+        self.assertEqual(send_message_status, True)
 
-    def test_subcomment_should_not_send_email(self):
-        self.run_should_not_send_email_test(self.thread, self.subcomment)
+    def test_subcomment_should_send_email(self):
+        self.run_should_send_email_test(self.thread, self.subcomment)
 
-    def test_second_comment_should_not_send_email(self):
-        self.run_should_not_send_email_test(self.thread, self.comment2)
+    def test_second_comment_should_send_email(self):
+        self.run_should_send_email_test(self.thread, self.comment2)
 
-    def test_thread_without_children_should_not_send_email(self):
+    def test_thread_without_children_should_send_email(self):
         """
-        test that email notification will not be sent for the thread
+        test that email notification will be sent for the thread
         that doesn't have attribute 'children'
         """
-        self.run_should_not_send_email_test(self.thread2, self.comment)
+        self.run_should_send_email_test(self.thread2, self.comment)
 
     @ddt.data((
         {


### PR DESCRIPTION
**Description:**  This PR enables Forum notifications for threads and removes the restriction of only first comment related notification.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-1650

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.