### PR TITLE
Filter courses based on organization of current sites before serving

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.features.course_experience.waffle import waffle as course_experience_waffle
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
-from openedx.features.edly.utils import get_edx_org_from_cookie, get_enabled_organizations
+from openedx.features.edly.utils import filter_courses_based_on_org, get_edx_org_from_cookie, get_enabled_organizations
 from six import text_type
 
 from contentstore.course_group_config import (
@@ -514,6 +514,7 @@ def _accessible_courses_list_from_groups(request):
     staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
     site_courses = UserBasedRole(request.user, GlobalCourseCreatorRole.ROLE).courses_with_role()
     all_courses = filter(filter_ccx, instructor_courses | staff_courses | site_courses)
+    all_courses = filter_courses_based_on_org(request, all_courses)
     courses_list = []
     course_keys = {}
 

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -290,3 +290,26 @@ def user_can_login_on_requested_edly_organization(request, user):
         return True
 
     return False
+
+
+def filter_courses_based_on_org(request, all_courses):
+    """
+    Filter courses based on the requested URL site.
+
+    Most of our LMS based roles are not organization based we would
+    need to filter courses manually based on org of current site.
+
+    Arguments:
+        request: HTTP request object,
+        all_courses (iterator): Iterator object.
+
+    Returns:
+        list: Returns List of courses filtered based on current site organization.
+    """
+
+    edly_user_info_cookie = request.COOKIES.get(settings.EDLY_USER_INFO_COOKIE_NAME, None)
+    edx_org = get_edx_org_from_cookie(edly_user_info_cookie)
+
+    filtered_courses = [course for course in list(all_courses) if course.org == edx_org]
+
+    return filtered_courses


### PR DESCRIPTION
**Description**: Filtered courses based on the organization of current sites before serving
**Jira**: https://edlyio.atlassian.net/browse/EDLY-1811

**Testing**:
Login with course_creator role on multiple sites to verify they have courses of their sites only.

