### PR TITLE
Updates serializer to accept username instead of id

### DIFF
--- a/openedx/features/subscriptions/api/v1/serializers.py
+++ b/openedx/features/subscriptions/api/v1/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from django.contrib.auth.models import User
+
 from openedx.features.subscriptions.models import UserSubscription
 from enrollment.serializers import CourseEnrollmentSerializer
 
@@ -13,3 +15,15 @@ class UserSubscriptionSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserSubscription
         fields = ['subscription_id', 'subscription_type', 'expiration_date', 'course_enrollments', 'max_allowed_courses', 'user']
+
+    def to_internal_value(self, data):
+        """
+        Deserializer username to user object.
+        """
+        username = data.get('user')
+        try:
+            data['user'] = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise serializers.ValidationError('User with username {} does not exist'.format(username))
+
+        return super(UserSubscriptionSerializer, self).to_internal_value(data)

--- a/openedx/features/subscriptions/api/v1/views.py
+++ b/openedx/features/subscriptions/api/v1/views.py
@@ -50,8 +50,8 @@ class SubscriptionRetrieveUpdateView(PutAsCreateMixin, RetrieveUpdateAPIView):
     ordering = ['-created']
 
     def get_object(self, queryset=None):
-        user_id = self.request.user.id
-        self.kwargs['user'] = user_id
+        username = self.request.data.get('user', self.request.user.username)
+        self.kwargs['user__username'] = username
         user_subscription = UserSubscription.objects.filter(**self.kwargs).first()
 
         if not user_subscription:


### PR DESCRIPTION
**Description:**
Previously, user id was being sent from ecommerce to create a user subscription in LMS. But user ids for a user may differ on both services. This change fixes this issue by accepting username from ecommerce and getting user id from it.