### PR TITLE
Adds check for anonymous user

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -12,7 +12,6 @@ Note: The access control logic in this file does NOT check for enrollment in
 """
 import logging
 from datetime import datetime
-import waffle
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -338,10 +337,6 @@ def _has_access_course(user, action, courselike):
         # ).or(
         #     _has_staff_access_to_descriptor, user, courselike, courselike.id
         # )
-        user_has_active_subscription = is_course_accessible_with_subscription(user, courselike)
-        if not user_has_active_subscription:
-            return user_has_active_subscription
-
         visible_to_nonstaff = _visible_to_nonstaff_users(courselike)
         if not visible_to_nonstaff:
             staff_access = _has_staff_access_to_descriptor(user, courselike, courselike.id)
@@ -373,6 +368,14 @@ def _has_access_course(user, action, courselike):
                 return staff_access
             else:
                 return has_not_expired
+
+        user_has_active_subscription = is_course_accessible_with_subscription(user, courselike)
+        if not user_has_active_subscription:
+            staff_access = _has_staff_access_to_descriptor(user, courselike, courselike.id)
+            if staff_access:
+                return staff_access
+            else:
+                return user_has_active_subscription
 
         return ACCESS_GRANTED
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -338,14 +338,9 @@ def _has_access_course(user, action, courselike):
         # ).or(
         #     _has_staff_access_to_descriptor, user, courselike, courselike.id
         # )
-        if waffle.switch_is_active(settings.ENABLE_SUBSCRIPTIONS_ON_RUNTIME_SWITCH):
-            user_has_active_subscription = is_course_accessible_with_subscription(user, courselike)
-            if not user_has_active_subscription:
-                staff_access = _has_staff_access_to_descriptor(user, courselike, courselike.id)
-                if staff_access:
-                    return staff_access
-                else:
-                    return user_has_active_subscription
+        user_has_active_subscription = is_course_accessible_with_subscription(user, courselike)
+        if not user_has_active_subscription:
+            return user_has_active_subscription
 
         visible_to_nonstaff = _visible_to_nonstaff_users(courselike)
         if not visible_to_nonstaff:

--- a/openedx/features/subscriptions/utils.py
+++ b/openedx/features/subscriptions/utils.py
@@ -2,7 +2,6 @@ import waffle
 from django.conf import settings
 
 from courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED
-from lms.djangoapps.courseware.masquerade import get_course_masquerade
 from openedx.features.subscriptions.models import UserSubscription
 
 from student.models import User

--- a/openedx/features/subscriptions/utils.py
+++ b/openedx/features/subscriptions/utils.py
@@ -27,6 +27,9 @@ def is_course_accessible_with_subscription(user, course):
     """
     Check if user has access to a course enrolled through subscription.
     """
+    if user.is_anonymous:
+        return ACCESS_GRANTED
+
     course_enrolled_subscriptions = UserSubscription.objects.filter(user=user, course_enrollments__course__id=course.id)
     if not course_enrolled_subscriptions:
         return ACCESS_GRANTED

--- a/openedx/features/subscriptions/utils.py
+++ b/openedx/features/subscriptions/utils.py
@@ -1,4 +1,8 @@
+import waffle
+from django.conf import settings
+
 from courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED
+from lms.djangoapps.courseware.access import _has_staff_access_to_descriptor
 from openedx.features.subscriptions.models import UserSubscription
 
 from student.models import User
@@ -23,12 +27,16 @@ def track_subscription_enrollment(subscription_id, user, course_id, site):
             valid_user_subscription.course_enrollments.add(enrollment)
             valid_user_subscription.save()
 
+
 def is_course_accessible_with_subscription(user, course):
     """
     Check if user has access to a course enrolled through subscription.
     """
-    if user.is_anonymous:
+    if waffle.switch_is_active(settings.ENABLE_SUBSCRIPTIONS_ON_RUNTIME_SWITCH):
         return ACCESS_GRANTED
+
+    if not user or not user.is_authenticated:
+        return ACCESS_DENIED
 
     course_enrolled_subscriptions = UserSubscription.objects.filter(user=user, course_enrollments__course__id=course.id)
     if not course_enrolled_subscriptions:
@@ -38,4 +46,4 @@ def is_course_accessible_with_subscription(user, course):
         if subscription.is_active:
             return ACCESS_GRANTED
 
-    return ACCESS_DENIED
+    return _has_staff_access_to_descriptor(user, course, course.id)


### PR DESCRIPTION
**Description:**
Adds check for anonymous user to avoid 500.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2105

**Some important notes:**
- Course access check for learner works on a short circuit pattern. There are 6 conditions (including our subscription one) that are applied to check a user's access to a course. if any of them restricts access to the course, the following conditions are ignored.
- The subscription access check has been pushed to last due to the reason that all edX's existing checks must be run before checking for subscription access as it ensures that all possible restrictions except subscription access have already been applied
- `is_course_accessible_with_subscription` should only apply restriction if a course enrollment for a given user in a given course is found in an inactive subscription. The change in this PR ensures this. `ACCESS_DENIED` is only returned if an inactive subscription is found that has an enrollment record of a given user in a given course.