### PR TITLE
Updates regex expression to match case insensitive exact org name

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -8,7 +8,7 @@ from urlparse import urlparse, urlunparse
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Q
-from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, IntegerField, FloatField
+from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, FloatField, IntegerField
 from django.db.utils import IntegrityError
 from django.template import defaultfilters
 

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -7,7 +7,8 @@ from urlparse import urlparse, urlunparse
 
 from django.conf import settings
 from django.db import models, transaction
-from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, FloatField, IntegerField
+from django.db.models import Q
+from django.db.models.fields import BooleanField, DateTimeField, DecimalField, TextField, IntegerField, FloatField
 from django.db.utils import IntegrityError
 from django.template import defaultfilters
 
@@ -576,7 +577,11 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            org_filter = Q()  # Avoiding the `reduce()` for more readability, so a no-op filter starter is needed.
+            for org in orgs:
+                org_filter |= Q(org__iexact=org)
+
+            course_overviews = course_overviews.filter(org_filter)
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
**Description:**
Updates org filter regex expression. Details on the JIRA ticket.
_Issue:_
Due to the regex matching while filtering courses (https://github.com/edly-io/edx-platform/blob/0680d4492dc0c1a7da662560577c6bec7c9e2398/openedx/core/djangoapps/content/course_overviews/models.py#L579), Trial filters courses including those of Trial1 and Trial2. This means that any org name where one org has a same name w.r.t to another with case changed or the org name is a substring to another organization name, courses of that org would also be included.
![image](https://user-images.githubusercontent.com/20854114/96864141-67d0b580-1481-11eb-8a01-0c1f65192d38.png)

 _Fix:_
This issue has been fixed by cherry-picking the following commit: https://github.com/edx/edx-platform/commit/99960d7001f2378c2918e60a5a1f5b9de621fc68

The new query is:
![image](https://user-images.githubusercontent.com/20854114/96863905-07da0f00-1481-11eb-9739-ad53d99d3ab1.png)

**Related edX PR:** https://github.com/edx/edx-platform/pull/14471/

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2126
