### PR TITLE
Fix API_HOST_URL format in user sites API

### DIFF
--- a/openedx/features/edly/api/serializers.py
+++ b/openedx/features/edly/api/serializers.py
@@ -19,7 +19,7 @@ class UserSiteSerializer(serializers.Serializer):
             default=''
         )
         protocol = 'https' if self.context['request'].is_secure() else 'http'
-        mobile_app_config['API_HOST_URL'] = '{}//:{}'.format(protocol, url) if url else ''
+        mobile_app_config['API_HOST_URL'] = '{}://{}'.format(protocol, url) if url else ''
         mobile_app_config['ORGANIZATION_CODE'] = self.context['edly_sub_org_of_user'].edx_organization.short_name
         return mobile_app_config
 

--- a/openedx/features/edly/api/tests/test_serializers.py
+++ b/openedx/features/edly/api/tests/test_serializers.py
@@ -59,7 +59,7 @@ class UserSiteSerializerTests(TestCase):
 
         protocol = 'https' if self.request.is_secure() else 'http'
         url = self.test_site_configuration['SITE_NAME']
-        expected_api_host_url = '{}//:{}'.format(protocol, url) if url else ''
+        expected_api_host_url = '{}://{}'.format(protocol, url) if url else ''
         assert expected_api_host_url == serializer.data['app_config'].get('API_HOST_URL')
 
     def test_site_data(self):


### PR DESCRIPTION
**Description: ** Fixed API_HOST_URL format while concatenating string

**Related PR: ** https://github.com/edly-io/edx-platform/pull/155

**Related Ticket: ** https://edlyio.atlassian.net/browse/EDLY-1737

Previously it was
```
"API_HOST_URL": "http//:edx.devstack.lms:18000"
```

Now it's
```
"API_HOST_URL": "http://edx.devstack.lms:18000"
```