### PR TITLE
Fixed exception in VisibleBlocks.bulk_create due to incorrect argument

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -223,7 +223,7 @@ class VisibleBlocks(models.Model):
         only for those that aren't already created.
         """
         cached_records = cls.bulk_read(user_id, course_key)
-        non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
+        non_existent_brls = {brl for brl in block_record_lists if brl.hash_value not in cached_records}
         cls.bulk_create(user_id, course_key, non_existent_brls)
 
     @classmethod


### PR DESCRIPTION
**Description:**  This PR fixed exception in `VisibleBlocks.bulk_create` due to an incorrect argument.

This error happens when we try to generate a learner's grade after the PersitGrade feature is enabled.
`brl.hash_value is 'str' type. It is supposed to be a BlockRecordList object.`

**JIRA:** 
https://openedx.atlassian.net/browse/OSPR-3204

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.