### PR TITLE
Enable auto genreated certificates for honor mode seats

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -125,6 +125,7 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
         CourseMode.CREDIT_MODE,
         CourseMode.PROFESSIONAL,
         CourseMode.NO_ID_PROFESSIONAL_MODE,
+        CourseMode.HONOR,
     ]
     enrollment_mode, __ = CourseEnrollment.enrollment_mode_for_user(user, course_key)
     cert = GeneratedCertificate.certificate_for_student(user, course_key)

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -311,7 +311,7 @@ class CertificateGenerationTaskTest(ModuleStoreTestCase):
         ('no-id-professional', True),
         ('credit', True),
         ('audit', False),
-        ('honor', False),
+        ('honor', True),
     )
     @ddt.unpack
     def test_fire_ungenerated_certificate_task_allowed_modes(self, enrollment_mode, should_create):


### PR DESCRIPTION
**Description** This PR enables auto-generated certificates for honor mode seats. 

**How to make it work?**
1. Add waffle switch `certificates.auto_certificate_generation` and enable it
<img width="1437" alt="Screenshot 2020-11-04 at 12 33 10 PM" src="https://user-images.githubusercontent.com/15142776/98083772-a9f3f100-1e9c-11eb-81af-4d9fa74ea9c8.png">


**Jira:** https://edlyio.atlassian.net/browse/EDLY-2188

<img width="1437" alt="Screenshot 2020-11-04 at 12 27 36 PM" src="https://user-images.githubusercontent.com/15142776/98083916-ddcf1680-1e9c-11eb-8588-e9c4bbc07a91.png">


