### PR TITLE
Fix: Facebook share for certificates

### DIFF
--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -51,10 +51,10 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                     % if facebook_share_enabled:
                       <button class="action action-share-facebook btn-inverse btn-small icon-only" id="action-share-facebook"
                          onclick="FaceBook.share({
-                          share_text: '${facebook_share_text | n, js_escaped_string}', ## xss-lint: disable=mako-invalid-html-filter
-                          share_link: '${share_url | n, js_escaped_string}', ## xss-lint: disable=mako-invalid-html-filter
-                          picture_link: '${full_course_image_url | n, js_escaped_string}', ## xss-lint: disable=mako-invalid-html-filter
-                          description: '${_('Click the link to see my certificate.') | n, js_escaped_string}' ## xss-lint: disable=mako-invalid-html-filter
+                          share_text: '${facebook_share_text | n, js_escaped_string}',
+                          share_link: '${share_url | n, js_escaped_string}',
+                          picture_link: '${full_course_image_url | n, js_escaped_string}',
+                          description: '${_('Click the link to see my certificate.') | n, js_escaped_string}'
                           });">
                           <span class="icon fa fa-facebook-official" aria-hidden="true"></span>
                           <span class="action-label">${_("Post on Facebook")}</span>


### PR DESCRIPTION
**Description:** 
This PR fixes the Facebook share for the certificates. The problem was that Mako comments were added in JavaScript code and that causing the invalid syntax error. `SyntaxError: Invalid character: '#'`

**JIRA:** Link to JIRA ticket
https://edlyio.atlassian.net/browse/EDLY-1976

**Screenshot**
![image](https://user-images.githubusercontent.com/7139602/98236999-0979fb80-1f86-11eb-83da-788f9e8b6220.png)

 