### PR TITLE
Use site_configuration to pull extra fields values before pulling value from settings

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -136,10 +136,9 @@ def create_account_with_params(request, params):
 
     extended_profile_fields = configuration_helpers.get_value('extended_profile_fields', [])
     # Can't have terms of service for certain SHIB users, like at Stanford
-    registration_fields = getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
     tos_required = (
-        registration_fields.get('terms_of_service') != 'hidden' or
-        registration_fields.get('honor_code') != 'hidden'
+        extra_fields.get('terms_of_service') != 'hidden' or
+        extra_fields.get('honor_code') != 'hidden'
     ) and (
         not settings.FEATURES.get("AUTH_USE_SHIB") or
         not settings.FEATURES.get("SHIB_DISABLE_TOS") or

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -679,6 +679,8 @@ class TestCreateAccountValidation(TestCase):
         self.assertLess(len(params["email"]), 254)
         self.assert_success(params)
 
+        self.client.logout()
+
         # Invalid
         params["email"] = "not_an_email_address"
         assert_email_error("A properly formatted e-mail is required")
@@ -783,6 +785,8 @@ class TestCreateAccountValidation(TestCase):
             # True
             params["honor_code"] = "tRUe"
             self.assert_success(params)
+
+            self.client.logout()
 
         with override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "optional"}):
             # Missing


### PR DESCRIPTION
**Description:** Used site_configuration to pull extra fields values before pulling value from settings
**Jira:** https://edlyio.atlassian.net/browse/EDLY-2182

Registration form with honor code as optional in site configuration:
<img width="1552" alt="Screenshot 2020-11-06 at 11 15 44 AM" src="https://user-images.githubusercontent.com/15142776/98338255-b9ee0b00-202b-11eb-99fd-2cdd758352b7.png">

Registration form with honor code as hidden in site configuration:
<img width="1552" alt="Screenshot 2020-11-06 at 11 18 29 AM" src="https://user-images.githubusercontent.com/15142776/98338292-ca9e8100-202b-11eb-9809-776218d2c483.png">

Registration form without any site configuration:
<img width="1552" alt="Screenshot 2020-11-06 at 11 20 21 AM" src="https://user-images.githubusercontent.com/15142776/98338310-d427e900-202b-11eb-8b71-1c1ec8721f11.png">

