### PR TITLE
Fixed default email address in User Retirement Email

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -401,7 +401,7 @@ class DeactivateLogoutView(APIView):
 
                 try:
                     # Send notification email to user
-                    site = Site.objects.get_current()
+                    site = Site.objects.get_current(request)
                     notification_context = get_base_template_context(site)
                     notification_context.update({'full_name': request.user.profile.name})
                     notification = DeletionNotificationMessage().personalize(


### PR DESCRIPTION
**Description:**
This PR fixes the issue where the default email address showed on user retirement email. The problem was that Django Site framework didn't recognize the current site and return the default site instance. Due to this, the value of `contact_email`  didn't reflect in the email

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-2274