### PR TITLE
Fix: Wrong error message shows during user retirement process

### DIFF
--- a/lms/static/js/student_account/AccountsClient.js
+++ b/lms/static/js/student_account/AccountsClient.js
@@ -15,7 +15,7 @@ const deactivate = (password) => fetch('/api/user/v1/accounts/deactivate_logout/
     return response;
   }
 
-  throw new Error(response);
+  throw new Error(response.status);
 });
 
 export {


### PR DESCRIPTION
**Description:** Describe in a couple of sentence what this PR does along with a list of changes.
This PR fixs the issue where the wrong error message shows upon adding the wrong password during the retirement process

**Note:**
Code originally copy from the edX Juniper commit https://github.com/edx/edx-platform/commit/b0cb5bb1e7861a59c4854284d81dcd922085c26b#diff-84c0bfd4fb365e71aa9a5529db56f5d079ecc8c7d1a15dc2d0935a9ad33c1b81

**JIRA:** Link to JIRA ticket
https://edlyio.atlassian.net/browse/EDLY-2281

