### PR TITLE
EDLY-2263 Override default invalid certificate configuration values

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -44,6 +44,7 @@ from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
 from openedx.core.djangoapps.certificates.api import display_date_for_certificate, certificates_viewable_for_course
+from openedx.features.edly.utils import get_current_site_invalid_certificate_context
 from student.models import LinkedInAddToProfileConfiguration
 from util import organizations_helpers as organization_api
 from util.date_utils import strftime_localized
@@ -158,7 +159,8 @@ def _update_context_with_basic_info(context, course_id, platform_name, configura
     context['course_id'] = course_id
 
     # Update the view context with the default ConfigurationModel settings
-    context.update(configuration.get('default', {}))
+    current_site_context_data = get_current_site_invalid_certificate_context(configuration)
+    context.update(current_site_context_data)
 
     # Translators:  'All rights reserved' is a legal term used in copyrighting to protect published content
     reserved = _("All rights reserved")

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -8,6 +8,8 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.forms.models import model_to_dict
 
+from lms.djangoapps.branding.api import get_logo_url, get_privacy_url, get_tos_and_honor_code_url
+from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration
 from openedx.features.edly.models import EdlyUserProfile, EdlySubOrganization
 from student import auth
 from student.roles import (
@@ -333,3 +335,31 @@ def create_learner_link_with_permission_groups(user):
         user.groups.add(new_group)
 
     return user
+
+
+def get_current_site_invalid_certificate_context(default_html_certificate_configuration):
+    """
+    Gets current site's context data for invalid certificate.
+
+    Try to get current site's context data for invalid certificate from site configuration
+    or fallback to empty urls.
+
+    Arguments:
+        default_html_certificate_configuration (dict): Default html configurations dict.
+
+    Returns:
+        dict: Context data.
+    """
+    context = dict(default_html_certificate_configuration.get('default'))
+    current_site_configuration = get_current_site_configuration()
+
+    if not current_site_configuration:
+        return context
+
+    context['platform_name'] = current_site_configuration.get_value('platform_name', settings.PLATFORM_NAME)
+    context['logo_src'] = get_logo_url()
+    logo_redirect_url = settings.LMS_ROOT_URL
+    context['logo_url'] = logo_redirect_url
+    context['company_privacy_url'] = get_privacy_url()
+    context['company_tos_url'] = get_tos_and_honor_code_url()
+    return context


### PR DESCRIPTION
**Description:**
Added method to get the current site's context data for an invalid certificate from site configuration or fallback to default HTML certificate configurations.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2263
