### PR TITLE
Upgrade Figures Release Tags to edly-1.4.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -31,7 +31,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
--e git+https://github.com/edly-io/figures.git@edly-1.0.0#egg=figures==edly-1.2.0
+-e git+https://github.com/edly-io/figures.git@edly-1.4.0#egg=figures==edly-1.4.0
 -e git+https://github.com/edly-io/edx_xblock_scorm.git@v1.0.5#egg=edx_xblock_scorm==v1.0.5
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -43,7 +43,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-d
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e git+https://github.com/edly-io/xblock-pdf.git@edly-1.0.1#egg=xblock-pdf
 git+ssh://git@github.com/edly-io/edly-panel-edx-app.git@edly-1.4.2#egg=edly-panel-app==edly-1.4.2
-git+ssh://git@github.com/edly-io/figures.git@edly-1.0.0#egg=figures==edly-1.2.0
+git+ssh://git@github.com/edly-io/figures.git@edly-1.4.0#egg=figures==edly-1.4.0
 -e git+https://github.com/edly-io/edx_xblock_scorm.git@v1.0.5#egg=edx_xblock_scorm==v1.0.5
 -e git+https://github.com/edly-io/xblock-video.git@dev#egg=video_xblock
 -e common/lib/xmodule

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -70,7 +70,7 @@
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
--e git+https://github.com/edly-io/figures.git@edly-1.0.0#egg=figures==edly-1.2.0
+-e git+https://github.com/edly-io/figures.git@edly-1.4.0#egg=figures==edly-1.4.0
 -e git+https://github.com/edly-io/edx_xblock_scorm.git@v1.0.5#egg=edx_xblock_scorm==v1.0.5
 
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -32,7 +32,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 #git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 git+ssh://git@github.com/edly-io/edly-panel-edx-app.git@edly-1.4.2#egg=edly-panel-app==edly-1.4.2
-git+ssh://git@github.com/edly-io/figures.git@edly-1.0.0#egg=figures==edly-1.2.0
+git+ssh://git@github.com/edly-io/figures.git@edly-1.4.0#egg=figures==edly-1.4.0
 -e git+https://github.com/edly-io/edx_xblock_scorm.git@v1.0.5#egg=edx_xblock_scorm==v1.0.5
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages


### PR DESCRIPTION
**Description:**  This PR update release tags for `figures` to `edly-1.4.0`

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.