### PR TITLE
Delete cookies when user retirement process complete

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -41,6 +41,7 @@ from openedx.core.djangoapps.credit.models import CreditRequirementStatus, Credi
 from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCohortAssignments
 from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
+from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models, retire_dop_oauth2_models
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 from openedx.core.lib.api.parsers import MergePatchParser
@@ -416,7 +417,9 @@ class DeactivateLogoutView(APIView):
 
                 # Log the user out.
                 logout(request)
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            response = Response(status=status.HTTP_204_NO_CONTENT)
+            delete_logged_in_cookies(response)
+            return response
         except KeyError:
             return Response(u'Username not specified.', status=status.HTTP_404_NOT_FOUND)
         except user_model.DoesNotExist:


### PR DESCRIPTION
**Description**
When the user completes the account deletion process. LMS logout the user forcefully but the user keeps logins on WordPress. The problem is the cookies didn't get deleted during the account deletion process.

The problem is  edX tries to delete the cookies through the JS code and due to hardcoded domain name its not able to delete any cookies https://github.com/edly-io/edx-platform/blob/master/lms/static/js/student_account/components/StudentAccountDeletion.jsx

I did try to delete the cookies without the domain argument but it gives the warning errors Cookie “edxloggedin” has been rejected for invalid domain. and as we have the multisite infrastructure we cant add the domains dynamically.

So I did delete the cookies in API view

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-2259