### PR TITLE
EDLY-2286 Allow organization access for the user if a user is a superuser or staff

### DIFF
--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -146,6 +146,14 @@ class UtilsTests(ModuleStoreTestCase):
         user_has_access = user_has_edly_organization_access(self.request)
         assert user_has_access is True
 
+    def test_staff_user_with_organization_access(self):
+        """
+        Test staff user have access to a valid site URL which is not linked to that user.
+        """
+        self.request.user = self.admin_user
+        user_has_access = user_has_edly_organization_access(self.request)
+        assert user_has_access is True
+
     def test_user_without_organization_access(self):
         """
         Test user has no access to a valid site URL but that site in not linked to the user.

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -38,6 +38,9 @@ def user_has_edly_organization_access(request):
         bool: Returns True if User has Edly Organization Access Otherwise False.
     """
 
+    if request.user.is_superuser or request.user.is_staff:
+        return True
+
     if getattr(request.user, 'edly_profile', None) is None:
         return False
 


### PR DESCRIPTION
**Description:** Allow organization access for the user if a user is a superuser or staff. The reason for escalating permissions checks is that our send_maus_emails command from edly-panel-backend tries to communicate via server to server communication which fails because that user won't have edly-user-info cookie set.

**JIRA:**  https://edlyio.atlassian.net/browse/EDLY-2286

**Related PRs:**
https://github.com/edly-io/edly-panel-backend/pull/57
https://github.com/edly-io/edly-panel-backend/pull/56
https://github.com/edly-io/edly-panel-backend/pull/55