### PR TITLE
Remove code tag in Studio import page EDLY-2196

### DIFF
--- a/cms/static/js/features/import/factories/import.js
+++ b/cms/static/js/features/import/factories/import.js
@@ -46,7 +46,7 @@ define([
                         msg = gettext('File format not supported. Please upload a file with a {ext} extension.')
                             .replace('{ext}', '<code>tar.gz</code>');
 
-                        $('.error-block').text(msg).show();
+                        $('.error-block').html(msg).show();
                     }
                 };
 


### PR DESCRIPTION
 **Description:** Remove code tag that was appearing when importing a course on Studio with a wrong file format.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2196

**Visible Changes:**
`Bug Report`
<img width="1440" alt="Screenshot 2020-11-04 at 10 33 33 AM" src="https://user-images.githubusercontent.com/68893403/102985836-a2aea280-4531-11eb-906c-998449f5a6cf.png">

`Fix` 
<img width="1051" alt="Screenshot 2020-12-23 at 6 18 05 PM" src="https://user-images.githubusercontent.com/68893403/103000438-e4991200-454c-11eb-901d-65f6f85148d4.png">


