### PR TITLE
Add contact email & marketing links in user sites api EDLY_2408

### DIFF
--- a/openedx/features/edly/api/serializers.py
+++ b/openedx/features/edly/api/serializers.py
@@ -5,6 +5,8 @@ import json
 
 from rest_framework import serializers
 
+from edxmako.shortcuts import marketing_link
+
 from openedx.core.djangoapps.site_configuration.helpers import get_value_for_org
 
 
@@ -60,6 +62,14 @@ class UserSiteSerializer(serializers.Serializer):
         )
         protocol = 'https' if self.context['request'].is_secure() else 'http'
         site_data['site_url'] = '{}://{}'.format(protocol, url) if url else ''
+        site_data['contact_email'] = get_value_for_org(
+            self.context['edly_sub_org_of_user'].edx_organization.short_name,
+            'contact_email',
+            default=''
+        )
+        site_data['tos'] = marketing_link('TOS')
+        site_data['honor'] = marketing_link('HONOR')
+        site_data['privacy'] = marketing_link('PRIVACY')
         return site_data
 
     def get_mobile_enabled(self, obj):  # pylint: disable=unused-argument


### PR DESCRIPTION
**Description:** Add client contact email and marketing links in `user_sites` api. 

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2408

**Visible Changes:**
`Site Configurations`:
```
{
  ...
  "contact_email":"contact@example.com",
  "MKTG_URLS":{
    "ROOT":"http://wordpress.edx.devstack.lms/",
    "TOS":"/tos",
    "HONOR":"/honor",
    "PRIVACY":"/privacy"
    ...
  } 
}
```
`contact_email`, `tos`, `honor`, and `privacy` are available in response now.
<img width="712" alt="Screenshot 2021-01-05 at 6 42 24 PM" src="https://user-images.githubusercontent.com/68893403/103653198-00a5a600-4f86-11eb-8672-f87a253b6702.png">

