### PR TITLE
Add marketing links of sub org in user sites api EDLY_2408

### DIFF
--- a/openedx/features/edly/api/serializers.py
+++ b/openedx/features/edly/api/serializers.py
@@ -5,9 +5,9 @@ import json
 
 from rest_framework import serializers
 
-from edxmako.shortcuts import marketing_link
-
 from openedx.core.djangoapps.site_configuration.helpers import get_value_for_org
+
+from openedx.features.edly.utils import get_marketing_link
 
 
 class UserSiteSerializer(serializers.Serializer):
@@ -60,16 +60,20 @@ class UserSiteSerializer(serializers.Serializer):
             'SITE_NAME',
             default=''
         )
-        protocol = 'https' if self.context['request'].is_secure() else 'http'
-        site_data['site_url'] = '{}://{}'.format(protocol, url) if url else ''
         site_data['contact_email'] = get_value_for_org(
             self.context['edly_sub_org_of_user'].edx_organization.short_name,
             'contact_email',
             default=''
         )
-        site_data['tos'] = marketing_link('TOS')
-        site_data['honor'] = marketing_link('HONOR')
-        site_data['privacy'] = marketing_link('PRIVACY')
+        marketing_urls = get_value_for_org(
+            self.context['edly_sub_org_of_user'].edx_organization.short_name,
+            'MKTG_URLS',
+            default={}
+        )
+        site_data['site_url'] = marketing_urls.get('ROOT')
+        site_data['tos'] = get_marketing_link(marketing_urls, 'TOS')
+        site_data['honor'] = get_marketing_link(marketing_urls, 'HONOR')
+        site_data['privacy'] = get_marketing_link(marketing_urls, 'PRIVACY')
         return site_data
 
     def get_mobile_enabled(self, obj):  # pylint: disable=unused-argument

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -1,4 +1,5 @@
 import logging
+from urlparse import urljoin
 
 import jwt
 import waffle
@@ -7,6 +8,7 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Q
 from django.forms.models import model_to_dict
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from lms.djangoapps.branding.api import get_logo_url, get_privacy_url, get_tos_and_honor_code_url
@@ -367,6 +369,8 @@ def get_current_site_invalid_certificate_context(default_html_certificate_config
     context['company_privacy_url'] = get_privacy_url()
     context['company_tos_url'] = get_tos_and_honor_code_url()
     return context
+
+
 def clean_django_settings_override(django_settings_override):
     """
     Enforce only allowed django settings to be overridden.
@@ -400,3 +404,14 @@ def clean_django_settings_override(django_settings_override):
 
     if validation_errors:
         raise ValidationError(validation_errors)
+
+
+def get_marketing_link(marketing_urls, name):
+    """
+    Returns the correct URL for a link to the marketing site
+    """
+    if name in marketing_urls:
+        return urljoin(marketing_urls.get('ROOT'), marketing_urls.get(name))
+    else:
+        LOGGER.warning("Cannot find corresponding link for name: %s", name)
+        return ''


### PR DESCRIPTION
**Description:** Add client contact email and marketing links of user's sub org in `user_sites` api. Also, change `site_url` value to main site url instead of LMS site url.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2408

**Related PR:**
[edly-io/edx-platform/pull/193](https://github.com/edly-io/edx-platform/pull/193)

**Visible Changes:**
`Site Configurations:`
```
{
  ...
  "contact_email":"contact@example.com",
  "MKTG_URLS":{
    "ROOT":"http://wordpress.edx.devstack.lms/",
    "TOS":"tos",
    "HONOR":"honor",
    "PRIVACY":"privacy"
    ...
  } 
}
```
<img width="700" alt="Screenshot 2021-01-12 at 1 07 02 PM" src="https://user-images.githubusercontent.com/68893403/104286754-4fe45d00-54d7-11eb-96bb-ca2272f53a6f.png">
