### PR TITLE
Fix logo url for invalid certificate EDLY_2440

### DIFF
--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -11,7 +11,7 @@ from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from lms.djangoapps.branding.api import get_logo_url, get_privacy_url, get_tos_and_honor_code_url
+from lms.djangoapps.branding.api import get_privacy_url, get_tos_and_honor_code_url
 from openedx.core.djangoapps.site_configuration.helpers import get_current_site_configuration
 from openedx.features.edly.models import EdlyUserProfile, EdlySubOrganization
 from student import auth
@@ -363,7 +363,7 @@ def get_current_site_invalid_certificate_context(default_html_certificate_config
         return context
 
     context['platform_name'] = current_site_configuration.get_value('platform_name', settings.PLATFORM_NAME)
-    context['logo_src'] = get_logo_url()
+    context['logo_src'] = current_site_configuration.get_value('BRANDING', {}).get('logo', '')
     logo_redirect_url = settings.LMS_ROOT_URL
     context['logo_url'] = logo_redirect_url
     context['company_privacy_url'] = get_privacy_url()


### PR DESCRIPTION
**Description:** Fix logo src url in header for invalid certificate.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2440
