### PR TITLE
Apply user validation on enrollment api EDLY-2436

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -30,6 +30,7 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeade
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
 from openedx.core.lib.log_utils import audit_log
+from openedx.features.edly.utils import is_course_org_same_as_site_org
 from openedx.features.enterprise_support.api import (
     ConsentApiServiceClient,
     EnterpriseApiException,
@@ -709,6 +710,13 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
                 data={
                     'message': u'The user {} does not exist.'.format(username)
                 }
+            )
+
+        course_org_same_as_site_org = is_course_org_same_as_site_org(request.site, course_id)
+        if not course_org_same_as_site_org:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={'message': u'The provided course {} is not found on this site.'.format(course_id)}
             )
 
         embargo_response = embargo_api.get_embargo_response(request, course_id, user)

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -415,3 +415,19 @@ def get_marketing_link(marketing_urls, name):
     else:
         LOGGER.warning("Cannot find corresponding link for name: %s", name)
         return ''
+
+def is_course_org_same_as_site_org(site, course_id):
+    """
+    Check if the course organization matches with the site organization.
+    """
+    try:
+        edly_sub_org = EdlySubOrganization.objects.get(lms_site=site)
+    except EdlySubOrganization.DoesNotExist:
+        LOGGER.info('No Edly sub organization found for site %s', site)
+        return False
+
+    if edly_sub_org.edx_organization.short_name == course_id.org:
+        return True
+
+    LOGGER.info('Course organization does not match site organization')
+    return False


### PR DESCRIPTION
**Description:** This PR adds validation check on enrollment api to restrict users from enrolling in a course which does not belong to the site.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2436

**Visible Changes:**
<img width="734" alt="Screenshot 2021-02-04 at 11 56 07 AM" src="https://user-images.githubusercontent.com/68893403/106856703-b9bfe300-66e0-11eb-9ece-eaa11a6bade7.png">


