### PR TITLE
Fix wrong marketing link for unenrolled courses

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -200,6 +200,7 @@ class CourseCardModel extends Backbone.Model {
         courseTitleLink = courseRun.course_url;
       } else if (!isEnrolled && courseRun.marketing_url) {
         courseTitleLink = CourseCardModel.updateMarketingUrl(courseRun);
+        courseTitleLink = courseTitleLink.split('/').slice(0, -2).join('/').concat('/courses');
       }
       this.set({
         certificate_url: courseRun.certificate_url,


### PR DESCRIPTION
**Description:** This pr is a temporary fix for the wrong marketing link for unenrolled courses on the program details page. In juniper, we wrote our data loader which overrides slug generated by course discovery so in juniper we won't need this fix.


