### PR TITLE
Adds roles rule to enable certificates access to course staff/instructor

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -36,9 +36,9 @@ perms[ASSIGN_TO_COHORTS] = HasAccessRule('staff')
 perms[EDIT_COURSE_ACCESS] = HasAccessRule('instructor')
 perms[EDIT_FORUM_ROLES] = HasAccessRule('staff')
 perms[EDIT_INVOICE_VALIDATION] = HasAccessRule('staff')
-perms[ENABLE_CERTIFICATE_GENERATION] = is_staff
-perms[GENERATE_CERTIFICATE_EXCEPTIONS] = is_staff
-perms[GENERATE_BULK_CERTIFICATE_EXCEPTIONS] = is_staff
+perms[ENABLE_CERTIFICATE_GENERATION] = is_staff | HasRolesRule('staff', 'instructor')
+perms[GENERATE_CERTIFICATE_EXCEPTIONS] = is_staff | HasRolesRule('staff', 'instructor')
+perms[GENERATE_BULK_CERTIFICATE_EXCEPTIONS] = is_staff | HasRolesRule('staff', 'instructor')
 perms[GIVE_STUDENT_EXTENSION] = HasAccessRule('staff')
 perms[VIEW_ISSUED_CERTIFICATES] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 # only global staff or those with the data_researcher role can access the data download tab


### PR DESCRIPTION
**Description:**
In juniper, each action in the instructor dashboard has some special permissions that are working behind it. A user may be seeing all the options but may not be able to do all those actions unless one is staff. Since in multisites we don't assign any user staff role, these changes assign those permissions to the user if the user is a global course creator.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2685