### PR TITLE
Cherry-picked Fix notify_credentials command key error

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
@@ -255,10 +255,10 @@ class Command(BaseCommand):
             user = User.objects.get(id=grade.user_id)
 
             # Grab mode/status from cert call
-            if course_cert_info:
-                key = (user.id, str(grade.course_id))
-                mode = course_cert_info[key].get('mode', None)
-                status = course_cert_info[key].get('status', None)
+            key = (user.id, str(grade.course_id))
+            cert_info = course_cert_info.get(key, {})
+            mode = cert_info.get('mode', None)
+            status = cert_info.get('status', None)
 
             send_grade_if_interesting(
                 user,

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -120,12 +120,11 @@ class TestNotifyCredentials(TestCase):
         call_command(Command(), '--dry-run', '--start-date', '2017-02-01')
         self.assertFalse(mock_send.called)
 
-    @mock.patch(COMMAND_MODULE + '.handle_cert_change')
     @mock.patch(COMMAND_MODULE + '.send_grade_if_interesting')
     @mock.patch(COMMAND_MODULE + '.handle_course_cert_changed')
-    def test_hand_off(self, mock_grade_cert_change, mock_grade_interesting, mock_program_changed):
+    def test_hand_off(self, mock_grade_interesting, mock_program_changed):
+        # pylint: disable=unused-argument
         call_command(Command(), '--start-date', '2017-02-01')
-        self.assertEqual(mock_grade_cert_change.call_count, 2)
         self.assertEqual(mock_grade_interesting.call_count, 2)
 
     @mock.patch(COMMAND_MODULE + '.time')


### PR DESCRIPTION
**Description**
This PR cherry-pick the solution that fixes the key error for the `notify_credentials` management command

Orginal PR link https://github.com/edx/edx-platform/commit/ebc2948f812808ab8eba8e4ed7f3654cec44d400

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-2716