### PR TITLE
Enable django debug toolbar on dev - EDLY_2768

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -953,3 +953,41 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+ACTIVE_DJANGO_DEBUG_TOOLBAR = ENV_TOKENS.get('ACTIVE_DJANGO_DEBUG_TOOLBAR', False)
+
+if ACTIVE_DJANGO_DEBUG_TOOLBAR:
+    INSTALLED_APPS += ['debug_toolbar']  # NOQA
+    INTERNAL_IPS = ('127.0.0.1',)
+    DDT_WHITELIST_PATHS = ('/render_player',)
+
+    MIDDLEWARE += [  # NOQA
+        'lms.djangoapps.discussion.django_comment_client.utils.QueryCountDebugMiddleware',
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ]
+
+    DEBUG_TOOLBAR_PANELS = (
+        'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.settings.SettingsPanel',
+        'debug_toolbar.panels.headers.HeadersPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.signals.SignalsPanel',
+        'debug_toolbar.panels.logging.LoggingPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    )
+
+    DEBUG_TOOLBAR_CONFIG = {
+        # Profile panel is incompatible with wrapped views
+        # See https://github.com/jazzband/django-debug-toolbar/issues/792
+        'DISABLE_PANELS': (
+            'debug_toolbar.panels.profiling.ProfilingPanel',
+        ),
+        'SHOW_TOOLBAR_CALLBACK': 'lms.envs.production.should_show_debug_toolbar',
+    }
+
+    def should_show_debug_toolbar(request):
+        if request.path.endswith(DDT_WHITELIST_PATHS):
+            return False
+        return True

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -265,3 +265,4 @@ zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requi
 
 # Added here to make migration from ironwood to juniper easy
 edx-django-oauth2-provider==1.3.5
+django-debug-toolbar==2.2


### PR DESCRIPTION
**Description:** This PR enables Django Debug Toolbar for dev multisites.

**JIRA:**
https://edlyio.atlassian.net/browse/EDLY-2768

**Visible Changes:**
<img width="1386" alt="Screenshot 2021-03-31 at 11 36 25 AM" src="https://user-images.githubusercontent.com/68893403/113100821-556b5c80-9215-11eb-87f5-0fbd8f95d1aa.png">
