### PR TITLE
Fix from_address for activation email

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -212,8 +212,11 @@ def compose_and_send_activation_email(user, profile, user_registration=None):
     root_url = configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
     msg = compose_activation_email(root_url, user, user_registration, route_enabled, profile.name)
     site = theming_helpers.get_current_site()
+    from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS') or (
+        configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+    )
 
-    send_activation_email.delay(str(msg), site.id)
+    send_activation_email.delay(str(msg), site.id, from_address)
 
 
 @login_required


### PR DESCRIPTION
**Description**
This PR fixes the issue where `from_email` doesn't set due to site configuration was not accessibly in celery task

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-2795