### PR TITLE
EDLY-2135 Optimise Edly mobile sites API

### DIFF
--- a/openedx/features/edly/api/tests/test_serializers.py
+++ b/openedx/features/edly/api/tests/test_serializers.py
@@ -58,6 +58,7 @@ class UserSiteSerializerTests(TestCase):
             enabled=True,
             site_values=self.test_site_configuration,
         )
+        self.context['site_configuration'] = self.site_configuration.site_values.copy()
 
     def validate_url(self, url):
         """
@@ -101,6 +102,7 @@ class UserSiteSerializerTests(TestCase):
 
         self.site_configuration.site_values['MOBILE_ENABLED'] = False
         self.site_configuration.save()
+        self.context['site_configuration'] = self.site_configuration.site_values.copy()
         serializer = self.serializer({}, context=self.context)
 
         assert not serializer.data['app_config']
@@ -110,7 +112,6 @@ class UserSiteSerializerTests(TestCase):
         Verify that `site_data` returns correct value.
         """
         serializer = self.serializer({}, context=self.context)
-
         for branding_key, branding_value in self.test_site_configuration['BRANDING'].items():
             assert branding_value == serializer.data['site_data'].get(branding_key)
 
@@ -137,6 +138,7 @@ class UserSiteSerializerTests(TestCase):
 
         self.site_configuration.site_values['MOBILE_ENABLED'] = False
         self.site_configuration.save()
+        self.context['site_configuration'] = self.site_configuration.site_values.copy()
         serializer = self.serializer({}, context=self.context)
 
         assert not serializer.data['mobile_enabled']

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from lms.djangoapps.mobile_api.decorators import mobile_view
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.features.edly.api.serializers import UserSiteSerializer
 
 
@@ -52,6 +53,11 @@ class UserSitesViewSet(viewsets.ViewSet):
         user_sites = []
         for edly_sub_org_of_user in edly_sub_orgs_of_user.all():
             context['edly_sub_org_of_user'] = edly_sub_org_of_user
+            site_configuration = SiteConfiguration.get_configuration_for_org(
+                edly_sub_org_of_user.edx_organization.short_name
+            )
+            site_configuration = site_configuration.__dict__.get('site_values', {}) if site_configuration else {}
+            context['site_configuration'] = site_configuration
             serializer = self.serializer({}, context=context)
             user_sites.append(
                 serializer.data


### PR DESCRIPTION
**Description:** This PR optimize edly mobile sites API by significantly dropping 22 databases queries to 6 queries only for each site.

<img width="1227" alt="Screenshot 2021-04-06 at 2 21 47 PM" src="https://user-images.githubusercontent.com/15142776/113689334-abdc0d80-96e3-11eb-9315-0faece60ab09.png">

**Jira:** https://edlyio.atlassian.net/browse/EDLY-2135