### PR TITLE
Enable REGISTRATION_EXTRA_FIELDS for phone field - EDLY-2815

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -647,7 +647,7 @@ def do_create_account(form, custom_form=None):
 
     profile_fields = [
         "name", "level_of_education", "gender", "mailing_address", "city", "country", "goals",
-        "year_of_birth"
+        "year_of_birth", "phone_number",
     ]
     profile = UserProfile(
         user=user,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1637,6 +1637,7 @@ ALLOWED_DJANGO_SETTINGS_OVERRIDE = [
     'DEFAULT_FROM_EMAIL', 'BULK_EMAIL_DEFAULT_FROM_EMAIL',
     'ECOMMERCE_API_URL', 'FEATURES', 'MKTG_URLS',
     'CREDENTIALS_INTERNAL_SERVICE_URL', 'CREDENTIALS_PUBLIC_SERVICE_URL',
+    'REGISTRATION_EXTRA_FIELDS',
 ]
 
 ENABLE_SUBSCRIPTIONS_ON_RUNTIME_SWITCH = 'enable_subscriptions'
@@ -2880,6 +2881,7 @@ REGISTRATION_FIELD_ORDER = [
     "country",
     "gender",
     "year_of_birth",
+    "phone_number",
     "level_of_education",
     "specialty",
     "profession"

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -315,6 +315,7 @@ class RegistrationFormFactory(object):
         "terms_of_service",
         "profession",
         "specialty",
+        "phone_number",
     ]
 
     def _is_field_visible(self, field_name):
@@ -1024,6 +1025,24 @@ class RegistrationFormFactory(object):
             error_messages={
                 "required": error_msg
             },
+        )
+
+    def _add_phone_number_field(self, form_desc, required=False):
+        """
+        Add a Phone Number field to a form description.
+
+        Arguments:
+            form_desc (str): A form description
+            required (bool): Whether this field is required; defaults to False
+        """
+        # Translators: This label appears above a field on the registration form
+        # which allows the user to input the Phone Number
+        first_name_label = _(u"Phone Number")
+
+        form_desc.add_field(
+            "phone_number",
+            label=first_name_label,
+            required=required
         )
 
     def _apply_third_party_auth_overrides(self, request, form_desc):


### PR DESCRIPTION
**Description:** This PR adds `REGISTRATION_EXTRA_FIELDS` back in `DJANGO_OVERRIDE_SETTINGS` in lms and adds `phone_number` field in user registration form.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-2815

**Visible Changes:**
<img width="424" alt="Screenshot 2021-04-08 at 3 41 21 PM" src="https://user-images.githubusercontent.com/68893403/114014396-001cf400-9882-11eb-8295-c466e6356fdf.png">
<img width="1373" alt="Screenshot 2021-04-08 at 3 49 00 PM" src="https://user-images.githubusercontent.com/68893403/114014637-3fe3db80-9882-11eb-9091-5a9967686f92.png">

