### PR TITLE
Fix Caption issue with YouTube

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -598,6 +598,7 @@
                             self.state.el.find('.lang').hide();
                             self.state.el.find('.transcript-control').hide();
                             self.subtitlesEl.hide();
+                            self.hideClosedCaptions();
                         }
                     }
                 });


### PR DESCRIPTION
**Description:**
This PR fixes the issue where the message `Caption will be displayed when you start playing the video.` shows for the Youtube video even the video doesn't have the caption.

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-3014

**Steps to reproduce** 

1. Add 2 videos to the unit. One is the default edX video and enable caption for this and add any other youtube video without caption.
2. Now play the edX video and enabled the cation option.
3. Refresh the page and you will see the message `(Caption will be displayed when you start playing the video.)` on second video which doesn't have any caption.
4. Play the second video and the message `(Caption will be displayed when you start playing the video.)` remains there.

**Video before the fix**

https://user-images.githubusercontent.com/7139602/120152323-c5429700-c206-11eb-89bf-b7310388b793.mov


**Video after the fix:**

https://user-images.githubusercontent.com/7139602/120152564-0dfa5000-c207-11eb-931c-6bbb3da3260e.mov

No message `(Caption will be displayed when you start playing the video.)` shows with the second video
