### PR TITLE
Fix: Subscriptions Expiry Emails Cron Job

### DIFF
--- a/openedx/features/subscriptions/management/commands/send_subscriptions_expiry_emails.py
+++ b/openedx/features/subscriptions/management/commands/send_subscriptions_expiry_emails.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         message_context = self._get_message_context(site)
         for subscription_id, user in context_values:
             if ace_message_class == ExpiredNotification:
-                subscription_renew_url = get_subscription_renew_url(subscription_id)
+                subscription_renew_url = get_subscription_renew_url(subscription_id, user)
                 message_context.update({
                     'subscription_renew_url': subscription_renew_url,
                     'subscription_id': subscription_id,

--- a/openedx/features/subscriptions/tests/test_utils.py
+++ b/openedx/features/subscriptions/tests/test_utils.py
@@ -88,15 +88,19 @@ class UtilsTests(ModuleStoreTestCase):
         """
         Test method return correct subscription renew url.
         """
-        self.assertEqual(get_subscription_renew_url(1), '')
+        self.assertEqual(get_subscription_renew_url(1, self.user), '')
         lifetime_subscription = UserSubscriptionFactory(
             subscription_type=UserSubscription.LIMITED_ACCESS
         )
-        self.assertEqual(get_subscription_renew_url(lifetime_subscription.subscription_id), '')
+        self.assertEqual(get_subscription_renew_url(lifetime_subscription.subscription_id, self.user), '')
         full_access_courses_subscription = UserSubscriptionFactory(
-            subscription_type=UserSubscription.FULL_ACCESS_COURSES
+            subscription_type=UserSubscription.FULL_ACCESS_COURSES,
+            user=self.user
         )
         subscription_renew_url = 'api/v2/subscriptions/renew_subscription/?subscription_id={subscription_id}'.format(
             subscription_id=full_access_courses_subscription.subscription_id
         )
-        self.assertEqual(get_subscription_renew_url(full_access_courses_subscription.subscription_id), subscription_renew_url)
+        self.assertEqual(
+            get_subscription_renew_url(full_access_courses_subscription.subscription_id, self.user),
+            subscription_renew_url
+        )

--- a/openedx/features/subscriptions/utils.py
+++ b/openedx/features/subscriptions/utils.py
@@ -9,7 +9,6 @@ from courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED
 from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.features.subscriptions.models import UserSubscription
 
-from student.models import User
 from student.models import CourseEnrollment
 
 
@@ -50,13 +49,14 @@ def is_course_accessible_with_subscription(user, course):
 
         return ACCESS_DENIED
 
-def get_subscription_renew_url(subscription_id):
+
+def get_subscription_renew_url(subscription_id, user):
     """
     Get subscription renew url if given subscription is renewable.
     """
     renew_subscription_path = ''
     try:
-        subscription = UserSubscription.objects.get(subscription_id=subscription_id)
+        subscription = UserSubscription.objects.get(subscription_id=subscription_id, user=user)
     except UserSubscription.DoesNotExist:
         return renew_subscription_path
 


### PR DESCRIPTION
**Description**
This PR fixes the issue where the subscription expiry emails cron job failed due to the `get() returned more than one UserSubscription ` error

**Jira Ticket**
https://edlyio.atlassian.net/browse/EDLY-3226