### PR TITLE
EDLY-3250 Remove text "webform at or " in Autogenerated email for account activation 

### DIFF
--- a/common/templates/student/edx_ace/accountactivation/email/body.html
+++ b/common/templates/student/edx_ace/accountactivation/email/body.html
@@ -48,7 +48,7 @@
         <td>
             <p style="color: rgba(0,0,0,.75);">
                 {% blocktrans trimmed asvar assist_msg %}
-                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ support_email }}{end_anchor}.
+                If you need help, please use our email {start_anchor_email}{{ support_email }}{end_anchor}.
                 {% endblocktrans %}
                 {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
                 <br />


### PR DESCRIPTION
**Description:**  Removed text "use webform at or" in Autogenerated email for account activation 
**JIRA:** https://edlyio.atlassian.net/browse/EDLY-3250
