### PR TITLE
Fix accounts api not returning timezone - EDLY-3200

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -184,6 +184,16 @@ class UserReadOnlySerializer(serializers.Serializer):
                 }
             )
 
+        data.update(
+            {
+                "time_zone": user.preferences.model.get_value(
+                    user,
+                    'time_zone',
+                    ''
+                ),
+            }
+        )
+
         if is_secondary_email_feature_enabled():
             data.update(
                 {


### PR DESCRIPTION
**Description:** This PR fixes the accounts api not returning the correct value for `time_zone` issue.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-3200

**Visible Changes:**

<img width="1373" alt="Screenshot 2021-07-09 at 3 10 09 PM" src="https://user-images.githubusercontent.com/68893403/125062387-c4373c00-e0c7-11eb-932e-d49628690cd4.png">
