### PR TITLE
Updates edx-org in cookies to edx-orgs with all edx-orgs of an Edly suborganization

### DIFF
--- a/openedx/features/edly/cookies.py
+++ b/openedx/features/edly/cookies.py
@@ -77,7 +77,7 @@ def _get_edly_user_info_cookie_string(request):
         edly_user_info_cookie_data = {
             'edly-org': edly_sub_organization.edly_organization.slug,
             'edly-sub-org': edly_sub_organization.slug,
-            'edx-org': edly_sub_organization.edx_organization.short_name,
+            'edx-orgs': edly_sub_organization.edx_organization.all().values_list('short_code', flat=True),
             'is_course_creator': auth.user_has_role(
                 request.user,
                 CourseCreatorRole()


### PR DESCRIPTION
## Description
Updates `edly-user-info` cookie to replace `edx-org` with `edx-orgs` that is a list of all the edX organizations belonging to an Edly suborganization.

Useful information to include:
- Course staff and "Learner" are likely to be impacted by this change

## Supporting information
https://edlyio.atlassian.net/browse/EDLY-3459

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline
By the end of current week
