### PR TITLE
Updates get_enabled_organizations to return all edx orgs of an edly suborganization

### DIFF
--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -142,12 +142,12 @@ def get_enabled_organizations(request):
         return get_organizations()
 
     try:
-        studio_site_edx_organization = model_to_dict(request.site.edly_sub_org_for_studio.edx_organization)
+        studio_site_edx_organizations = request.site.edly_sub_org_for_studio.edx_organizations.all()
     except EdlySubOrganization.DoesNotExist:
         LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
         return []
 
-    return [studio_site_edx_organization]
+    return studio_site_edx_organizations.values()
 
 
 def create_user_link_with_edly_sub_organization(request, user):

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -141,11 +141,9 @@ def get_enabled_organizations(request):
     if not waffle.switch_is_active(settings.ENABLE_EDLY_ORGANIZATIONS_SWITCH):
         return get_organizations()
 
-    try:
-        studio_site_edx_organizations = request.site.edly_sub_org_for_studio.edx_organizations.all()
-    except EdlySubOrganization.DoesNotExist:
+    studio_site_edx_organizations = request.site.edly_sub_org_for_studio.edx_organizations.all()
+    if not studio_site_edx_organizations:
         LOGGER.exception('No EdlySubOrganization found for site %s', request.site)
-        return []
 
     return studio_site_edx_organizations.values()
 


### PR DESCRIPTION
## Description

This PR updates the `get_enabled_organizations` helper method to return all edX organizations of an Edly suborganization.

## Supporting information
https://edlyio.atlassian.net/browse/EDLY-3461

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline
By the end of current week
