### PR TITLE
Fix libraries not visible for multiple orgs

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -546,11 +546,8 @@ def _accessible_libraries_iter(user, org=None):
         string will result in no libraries, and otherwise only libraries with the
         specified org will be returned. The default value is None.
     """
-    if org is not None:
-        if isinstance(org, list):
-            org = ','.join(org)
-
-        libraries = [] if org == '' else modulestore().get_libraries(org=org)
+    if org:
+        libraries = modulestore().get_libraries(org=org)
     else:
         libraries = modulestore().get_library_summaries()
     # No need to worry about ErrorDescriptors - split's get_libraries() never returns them.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -547,6 +547,9 @@ def _accessible_libraries_iter(user, org=None):
         specified org will be returned. The default value is None.
     """
     if org is not None:
+        if isinstance(org, list):
+            org = ','.join(org)
+
         libraries = [] if org == '' else modulestore().get_libraries(org=org)
     else:
         libraries = modulestore().get_library_summaries()

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -475,7 +475,7 @@ class MongoConnection(object):
                         query['search_targets.{}'.format(key)] = value
 
                 if org_target:
-                    query['org'] = { '$in': org_target }
+                    query['org'] = {'$in': org_target}
 
             return self.course_index.find(query)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -475,7 +475,7 @@ class MongoConnection(object):
                         query['search_targets.{}'.format(key)] = value
 
                 if org_target:
-                    query['org'] = org_target
+                    query['org'] = { '$in': org_target }
 
             return self.course_index.find(query)
 


### PR DESCRIPTION
## Description

This PR fixes multiple edx orgs libraries listing issue by introducing `$in` filter in mongo libraries query.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

https://edlyio.atlassian.net/browse/EDLY-3526

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
