### PR TITLE
Adds edx_organization factory field back until the field is permanently removed

### DIFF
--- a/openedx/features/edly/tests/factories.py
+++ b/openedx/features/edly/tests/factories.py
@@ -38,6 +38,7 @@ class EdlySubOrganizationFactory(DjangoModelFactory):
     name = Sequence('Edly SubOrganization {}'.format)
     slug = Sequence('edly-sub-organization-{}'.format)
     edly_organization = SubFactory(EdlyOrganizationFactory)
+    edx_organization = SubFactory(OrganizationFactory)
     lms_site = SubFactory(SiteFactory)
     studio_site = SubFactory(SiteFactory)
 


### PR DESCRIPTION
## Description

This PR adds back factory field for `edx_organization` untill it is permanently removed from `EdlySubOrganization`.