### PR TITLE
Makes edly staff role edly sub org based

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -8,7 +8,7 @@ to decide whether to check course creator role, and other such functions.
 
 from ccx_keys.locator import CCXBlockUsageLocator, CCXLocator
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from opaque_keys.edx.locator import LibraryLocator
 
 from student.roles import (
@@ -81,7 +81,7 @@ def get_user_permissions(user, course_key, org=None):
         org = course_key.org
         try:
             edly_sub_org = org.edlysuborganization
-        except Exception:
+        except ObjectDoesNotExist:
             edly_sub_org = None
 
         course_key = course_key.for_branch(None)

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -79,6 +79,11 @@ def get_user_permissions(user, course_key, org=None):
     """
     if org is None:
         org = course_key.org
+        try:
+            edly_sub_org = org.edlysuborganization
+        except Exception:
+            edly_sub_org = None
+
         course_key = course_key.for_branch(None)
     else:
         assert course_key is None
@@ -91,7 +96,7 @@ def get_user_permissions(user, course_key, org=None):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
-    if course_key and user_has_role(user, GlobalCourseCreatorRole(org)):
+    if course_key and user_has_role(user, GlobalCourseCreatorRole(edly_sub_org)):
         return all_perms
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -21,7 +21,7 @@ from six.moves import map
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.core.djangoapps.schedules.utils import reset_self_paced_schedule
-from openedx.features.edly.utils import get_edx_org_from_cookie
+from openedx.features.edly.utils import get_edly_sub_org_from_cookie
 
 import track.views
 from edxmako.shortcuts import render_to_response
@@ -75,8 +75,8 @@ def require_global_staff(func):
     @wraps(func)
     def wrapped(request, *args, **kwargs):
         edly_user_info_cookie = request.COOKIES.get(settings.EDLY_USER_INFO_COOKIE_NAME, None) if request else None
-        edx_org = get_edx_org_from_cookie(edly_user_info_cookie)
-        if GlobalStaff().has_user(request.user) or GlobalCourseCreatorRole(edx_org).has_user(request.user):
+        edly_sub_org = get_edly_sub_org_from_cookie(edly_user_info_cookie)
+        if GlobalStaff().has_user(request.user) or GlobalCourseCreatorRole(edly_sub_org).has_user(request.user):
             return func(request, *args, **kwargs)
         else:
             return HttpResponseForbidden(

--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -300,16 +300,16 @@ class UtilsTests(SharedModuleStoreTestCase):
         response = cookies_api.set_logged_in_edly_cookies(self.request, HttpResponse(), self.user, cookie_settings(self.request))
         self._copy_cookies_to_request(response, self.request)
         edly_user_info_cookie = self.request.COOKIES.get(settings.EDLY_USER_INFO_COOKIE_NAME)
-        edx_org = get_edx_org_from_cookie(edly_user_info_cookie)
+        edly_sub_org = get_edly_sub_org_from_cookie(edly_user_info_cookie)
         self.request.user = self.admin_user
 
         set_global_course_creator_status(self.request, self.user, True)
         assert self._get_course_creator_status(self.user) == 'granted'
-        assert auth.user_has_role(self.user, GlobalCourseCreatorRole(edx_org))
+        assert auth.user_has_role(self.user, GlobalCourseCreatorRole(edly_sub_org))
 
         set_global_course_creator_status(self.request, self.user, False)
         assert self._get_course_creator_status(self.user) == 'unrequested'
-        assert not auth.user_has_role(self.user, GlobalCourseCreatorRole(edx_org))
+        assert not auth.user_has_role(self.user, GlobalCourseCreatorRole(edly_sub_org))
 
         self.admin_user.is_staff = False
         self.admin_user.save()


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
