### PR TITLE
Fixes getting edly suborganization from course key org

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -83,7 +83,7 @@ def get_user_permissions(user, course_key, org=None):
         org = course_key.org
         organization = Organization.objects.get(short_name=org)
         try:
-            edly_sub_org = organization.edlysuborganization
+            edly_sub_org = organization.edx_organizations.first().slug
         except ObjectDoesNotExist:
             edly_sub_org = None
 

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from opaque_keys.edx.locator import LibraryLocator
 
+from organizations.models import Organization
+
 from student.roles import (
     CourseBetaTesterRole,
     CourseCreatorRole,
@@ -79,8 +81,9 @@ def get_user_permissions(user, course_key, org=None):
     """
     if org is None:
         org = course_key.org
+        organization = Organization.objects.get(short_name=org)
         try:
-            edly_sub_org = org.edlysuborganization
+            edly_sub_org = organization.edlysuborganization
         except ObjectDoesNotExist:
             edly_sub_org = None
 


### PR DESCRIPTION
## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
