### PR TITLE
Updated files to integrate authorizenet notifications

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1506,6 +1506,7 @@ a.fade-cover {
   width: flex-grid(12);
 }
 
+.course-upgrade,
 .account-activation {
   .message-copy {
     position: relative;

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -140,6 +140,14 @@ from common.djangoapps.student.models import CourseEnrollment
       </div>
     %endif
 
+    %if pending_upgrade_course_name:
+    <div class="course-upgrade aa-icon info" role="alert">
+      <div class="message-copy" >
+        Please wait for the confirmation email as your request is being processed. Course: ${ pending_upgrade_course_name } will be upgraded soon.
+      </div>
+    </div>
+    %endif
+
 </div>
 
 <main id="main" aria-label="Content" tabindex="-1">


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Show payment processing notification after payment completion.

Useful information to include:
- Cookie to Show notification first time only
- Show notification
