### PR TITLE
Update Course Rating API endpoint to list all the ratings

### DIFF
--- a/openedx/features/course_rating/api/tests/test_serializers.py
+++ b/openedx/features/course_rating/api/tests/test_serializers.py
@@ -39,7 +39,9 @@ class CourseRatingSerializerTests(TestCase):
                 'average_rating': '3.00',
                 'total_raters': 1
             },
-            'course': 'course-v1:edX+DemoX+Demo_Course'
+            'course': 'course-v1:edX+DemoX+Demo_Course',
+            'course_title': '',
+            'username': self.user.username
         }
         super(CourseRatingSerializerTests, self).setUp()
 

--- a/openedx/features/course_rating/api/tests/test_views.py
+++ b/openedx/features/course_rating/api/tests/test_views.py
@@ -35,7 +35,7 @@ class CourseRatingViewSet(TestCase):
         self.course = 'course-v1:edX+DemoX+Demo_Course'
         self.comment = 'Dummy test comment'
         self.user_course_rating = CourseRatingFactory(user=self.user, comment=self.comment, rating=5)
-        self.url = reverse('course_rating_api:course_rating-list', kwargs={'course_id': self.course})
+        self.url = reverse('course_rating_api:course_rating-list')
         super(CourseRatingViewSet, self).setUp()
 
     def test_without_permission(self):
@@ -93,7 +93,6 @@ class CourseRatingViewSet(TestCase):
         api_url = reverse(
             'course_rating_api:course_rating-detail',
             kwargs={
-                'course_id': self.course,
                 'pk': response.json()['id']
             }
         )

--- a/openedx/features/course_rating/api/v1/serializers.py
+++ b/openedx/features/course_rating/api/v1/serializers.py
@@ -4,6 +4,7 @@ Serializers for course_rating
 from rest_framework import serializers
 
 from openedx.features.course_rating.models import CourseRating, CourseAverageRating
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 
 class CourseRatingSerializer(serializers.ModelSerializer):
@@ -11,14 +12,26 @@ class CourseRatingSerializer(serializers.ModelSerializer):
     Serializer for "CourseRating" model
     """
     course_rating = serializers.SerializerMethodField()
+    username = serializers.CharField(source='user.username', read_only=True)
+    course_title = serializers.SerializerMethodField()
 
     class Meta:
         model = CourseRating
-        fields = ['id', 'course', 'course_rating', 'rating', 'comment', 'is_approved', 'user', 'moderated_by']
+        fields = [
+            'id', 'course', 'course_title', 'username', 'course_rating', 'rating',
+            'comment', 'is_approved', 'user', 'moderated_by'
+        ]
 
     def get_course_rating(self, obj):
         course_avg_rating = CourseAverageRating.objects.filter(course=obj.course).first()
         return CourseAverageRatingSerializer(course_avg_rating).data
+
+    def get_course_title(self, obj):
+        """
+        Get course title from "CourseOverview" model.
+        """
+        course_overview = CourseOverview.objects.filter(id=obj.course).first()
+        return course_overview.display_name if course_overview else ''
 
 
 class CourseAverageRatingSerializer(serializers.ModelSerializer):

--- a/openedx/features/course_rating/api/v1/urls.py
+++ b/openedx/features/course_rating/api/v1/urls.py
@@ -4,7 +4,6 @@ Defines URLs for the course rating.
 
 from django.conf.urls import include, url
 from rest_framework import routers
-from django.conf import settings
 
 from openedx.features.course_rating.api.v1.views import CourseRatingViewSet, CourseAverageRatingAPIView
 

--- a/openedx/features/course_rating/api/v1/urls.py
+++ b/openedx/features/course_rating/api/v1/urls.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from openedx.features.course_rating.api.v1.views import CourseRatingViewSet, CourseAverageRatingAPIView
 
 router = routers.DefaultRouter()
-router.register(r'course_rating/{}'.format(settings.COURSE_ID_PATTERN), CourseRatingViewSet, base_name='course_rating')
+router.register(r'course_rating', CourseRatingViewSet, base_name='course_rating')
 
 app_name = 'v1'
 

--- a/openedx/features/course_rating/api/v1/views.py
+++ b/openedx/features/course_rating/api/v1/views.py
@@ -24,15 +24,8 @@ class CourseRatingViewSet(viewsets.ModelViewSet):
     permission_classes = (CustomCourseRatingPermission,)
     serializer_class = CourseRatingSerializer
     filter_backends = [DjangoFilterBackend]
-    filter_fields = ['is_approved', 'user']
-
-    def get_queryset(self):
-        """
-        Filter course ratings.
-        """
-        course_id = self.kwargs['course_id']
-        course_key = CourseKey.from_string(course_id)
-        return CourseRating.objects.filter(course=course_key)
+    filter_fields = ['is_approved', 'user', 'course']
+    queryset = CourseRating.objects.all()
 
 
 class CourseAverageRatingAPIView(ListAPIView):


### PR DESCRIPTION
**Description:**  This PR adds updates Course Rating API endpoint to list all the ratings

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3866

**Updated URLs:**
**Listing:** http://edx.devstack.lms:18000/api/v1/course_rating/?course=course-v1:edX+DemoX+Demo_Course
**Detail:** http://edx.devstack.lms:18000/api/v1/course_rating/2/

**Merge checklist:**

- [ ] All reviewers approved
- [ ] Commits are (reasonably) squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
<img width="1147" alt="Screenshot 2021-11-04 at 2 26 15 PM" src="https://user-images.githubusercontent.com/17013371/140289571-6ad6f438-0db8-402c-8926-7b732cf1cf68.png">
