### PR TITLE
Mobile app is not working: Multiple Edx Organizations issue in User S…

### DIFF
--- a/openedx/features/edly/api/v1/views/tests/test_user_sites.py
+++ b/openedx/features/edly/api/v1/views/tests/test_user_sites.py
@@ -40,8 +40,8 @@ class TestUserSitesViewSet(TestCase):
         response = self.client.get(self.user_sites_list_url)
 
         assert response.status_code == 200
-
-        data = response.data[0]
+        print(response.data)
+        data = response.data
         assert data.get('site_data', {}).get('display_name') == self.request_site.name
         assert not data.get('app_config')
 

--- a/openedx/features/edly/api/v1/views/tests/test_user_sites.py
+++ b/openedx/features/edly/api/v1/views/tests/test_user_sites.py
@@ -37,11 +37,14 @@ class TestUserSitesViewSet(TestCase):
         """
         Verify that `list` returns correct response when user is logged in.
         """
+        print('sending api call')
+        print("self.user_sites_list_url: ", self.user_sites_list_url)
         response = self.client.get(self.user_sites_list_url)
+        print('status code: ', response.status_code)
 
         assert response.status_code == 200
         print(response.data)
-        data = response.data
+        data = response.data[0]
         assert data.get('site_data', {}).get('display_name') == self.request_site.name
         assert not data.get('app_config')
 

--- a/openedx/features/edly/api/v1/views/tests/test_user_sites.py
+++ b/openedx/features/edly/api/v1/views/tests/test_user_sites.py
@@ -26,7 +26,7 @@ class TestUserSitesViewSet(TestCase):
         self.edly_sub_org = EdlySubOrganizationFactory(lms_site=self.request_site, studio_site=self.request_site, preview_site=self.request_site)
         self.request = RequestFactory(SERVER_NAME=self.request_site.domain).get('')
         self.request.site = self.request_site
-        self.user = EdlyUserFactory(is_staff=True, is_superuser=True)
+        self.user = EdlyUserFactory(is_staff=False, is_superuser=False)
         self.request.user = self.user
         self.user.edly_profile.edly_sub_organizations.add(self.edly_sub_org)
         self.client = Client(SERVER_NAME=self.request_site.domain)
@@ -39,7 +39,10 @@ class TestUserSitesViewSet(TestCase):
         """
         print('sending api call')
         print("self.user_sites_list_url: ", self.user_sites_list_url)
+        print('self.request_site.domain: ', self.request_site.domain)
+
         response = self.client.get(self.user_sites_list_url)
+
         print('status code: ', response.status_code)
 
         assert response.status_code == 200

--- a/openedx/features/edly/api/v1/views/tests/test_user_sites.py
+++ b/openedx/features/edly/api/v1/views/tests/test_user_sites.py
@@ -26,7 +26,7 @@ class TestUserSitesViewSet(TestCase):
         self.edly_sub_org = EdlySubOrganizationFactory(lms_site=self.request_site, studio_site=self.request_site, preview_site=self.request_site)
         self.request = RequestFactory(SERVER_NAME=self.request_site.domain).get('')
         self.request.site = self.request_site
-        self.user = EdlyUserFactory(is_staff=False, is_superuser=False)
+        self.user = EdlyUserFactory(is_staff=True, is_superuser=True)
         self.request.user = self.user
         self.user.edly_profile.edly_sub_organizations.add(self.edly_sub_org)
         self.client = Client(SERVER_NAME=self.request_site.domain)

--- a/openedx/features/edly/api/v1/views/tests/test_user_sites.py
+++ b/openedx/features/edly/api/v1/views/tests/test_user_sites.py
@@ -37,16 +37,10 @@ class TestUserSitesViewSet(TestCase):
         """
         Verify that `list` returns correct response when user is logged in.
         """
-        print('sending api call')
-        print("self.user_sites_list_url: ", self.user_sites_list_url)
-        print('self.request_site.domain: ', self.request_site.domain)
-
         response = self.client.get(self.user_sites_list_url)
 
-        print('status code: ', response.status_code)
-
         assert response.status_code == 200
-        print(response.data)
+
         data = response.data[0]
         assert data.get('site_data', {}).get('display_name') == self.request_site.name
         assert not data.get('app_config')

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -43,7 +43,6 @@ class UserSitesViewSet(viewsets.ViewSet):
     serializer = UserSiteSerializer
 
     def list(self, request, *args, **kwargs):
-
         user = request.user
         edly_sub_orgs_of_user = user.edly_profile.edly_sub_organizations
 

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -54,6 +54,7 @@ class UserSitesViewSet(viewsets.ViewSet):
 
         user_sites = []
         for edly_sub_org_of_user in edly_sub_orgs_of_user.all():
+            print('edly_sub_org_of_user: ', edly_sub_org_of_user)
             context['edly_sub_org_of_user'] = edly_sub_org_of_user
             edx_organizations = edly_sub_org_of_user.get_edx_organizations
             print('edx_organizations: ', edx_organizations)

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -43,10 +43,9 @@ class UserSitesViewSet(viewsets.ViewSet):
     serializer = UserSiteSerializer
 
     def list(self, request, *args, **kwargs):
-        print("Now in the API Function")
+
         user = request.user
         edly_sub_orgs_of_user = user.edly_profile.edly_sub_organizations
-        print("edly_sub_orgs_of_user: ", edly_sub_orgs_of_user)
 
         context = {
             'request': request,
@@ -54,15 +53,14 @@ class UserSitesViewSet(viewsets.ViewSet):
 
         user_sites = []
         for edly_sub_org_of_user in edly_sub_orgs_of_user.all():
-            print('edly_sub_org_of_user: ', edly_sub_org_of_user)
             context['edly_sub_org_of_user'] = edly_sub_org_of_user
             edx_organizations = edly_sub_org_of_user.get_edx_organizations
-            print('edx_organizations: ', edx_organizations)
+
             for edx_organization in edx_organizations:
                 site_configuration = SiteConfiguration.get_configuration_for_org(edx_organization)
                 site_configuration = site_configuration.__dict__.get('site_values', {}) if site_configuration else {}
                 context['site_configuration'] = site_configuration
                 serializer = self.serializer({}, context=context)
                 user_sites.append(serializer.data)
-        print('user_sites: ', user_sites)
+
         return Response(user_sites)

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -53,14 +53,13 @@ class UserSitesViewSet(viewsets.ViewSet):
         user_sites = []
         for edly_sub_org_of_user in edly_sub_orgs_of_user.all():
             context['edly_sub_org_of_user'] = edly_sub_org_of_user
-            site_configuration = SiteConfiguration.get_configuration_for_org(
-                edly_sub_org_of_user.get_edx_organizations
-            )
-            site_configuration = site_configuration.__dict__.get('site_values', {}) if site_configuration else {}
-            context['site_configuration'] = site_configuration
-            serializer = self.serializer({}, context=context)
-            user_sites.append(
-                serializer.data
-            )
+            edx_organizations = edly_sub_org_of_user.get_edx_organizations
+
+            for edx_organization in edx_organizations:
+                site_configuration = SiteConfiguration.get_configuration_for_org(edx_organization)
+                site_configuration = site_configuration.__dict__.get('site_values', {}) if site_configuration else {}
+                context['site_configuration'] = site_configuration
+                serializer = self.serializer({}, context=context)
+                user_sites.append(serializer.data)
 
         return Response(user_sites)

--- a/openedx/features/edly/api/v1/views/user_sites.py
+++ b/openedx/features/edly/api/v1/views/user_sites.py
@@ -43,8 +43,10 @@ class UserSitesViewSet(viewsets.ViewSet):
     serializer = UserSiteSerializer
 
     def list(self, request, *args, **kwargs):
+        print("Now in the API Function")
         user = request.user
         edly_sub_orgs_of_user = user.edly_profile.edly_sub_organizations
+        print("edly_sub_orgs_of_user: ", edly_sub_orgs_of_user)
 
         context = {
             'request': request,
@@ -54,12 +56,12 @@ class UserSitesViewSet(viewsets.ViewSet):
         for edly_sub_org_of_user in edly_sub_orgs_of_user.all():
             context['edly_sub_org_of_user'] = edly_sub_org_of_user
             edx_organizations = edly_sub_org_of_user.get_edx_organizations
-
+            print('edx_organizations: ', edx_organizations)
             for edx_organization in edx_organizations:
                 site_configuration = SiteConfiguration.get_configuration_for_org(edx_organization)
                 site_configuration = site_configuration.__dict__.get('site_values', {}) if site_configuration else {}
                 context['site_configuration'] = site_configuration
                 serializer = self.serializer({}, context=context)
                 user_sites.append(serializer.data)
-
+        print('user_sites: ', user_sites)
         return Response(user_sites)

--- a/openedx/features/edly/tests/factories.py
+++ b/openedx/features/edly/tests/factories.py
@@ -39,6 +39,7 @@ class EdlySubOrganizationFactory(DjangoModelFactory):
     slug = Sequence('edly-sub-organization-{}'.format)
     edly_organization = SubFactory(EdlyOrganizationFactory)
     edx_organization = SubFactory(OrganizationFactory)
+    edx_organizations = SubFactory(OrganizationFactory)
     lms_site = SubFactory(SiteFactory)
     studio_site = SubFactory(SiteFactory)
 
@@ -54,8 +55,12 @@ class EdlySubOrganizationFactory(DjangoModelFactory):
         if extracted:
             edx_orgs = []
             edx_orgs.extend(extracted if isinstance(extracted, list) else [extracted])
+            
             for edx_org in edx_orgs:
                 self.edx_organizations.add(edx_org)
+        
+        else:
+            self.edx_organizations.add(self.edx_organization)
 
 
 

--- a/openedx/features/edly/tests/factories.py
+++ b/openedx/features/edly/tests/factories.py
@@ -55,10 +55,8 @@ class EdlySubOrganizationFactory(DjangoModelFactory):
         if extracted:
             edx_orgs = []
             edx_orgs.extend(extracted if isinstance(extracted, list) else [extracted])
-
             for edx_org in edx_orgs:
                 self.edx_organizations.add(edx_org)
-
         else:
             self.edx_organizations.add(self.edx_organization)
 

--- a/openedx/features/edly/tests/factories.py
+++ b/openedx/features/edly/tests/factories.py
@@ -55,10 +55,10 @@ class EdlySubOrganizationFactory(DjangoModelFactory):
         if extracted:
             edx_orgs = []
             edx_orgs.extend(extracted if isinstance(extracted, list) else [extracted])
-            
+
             for edx_org in edx_orgs:
                 self.edx_organizations.add(edx_org)
-        
+
         else:
             self.edx_organizations.add(self.edx_organization)
 


### PR DESCRIPTION
**Description**
The Mobile App was not working properly because of a recent change of multiple edx sub-organisations. The user sites API was not returning the relevant site data. After the fix, the API now returns the sites data for all sites in all edx sub-organisations linked to the user. 

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-3586

**Testing instructions:**

1. Open LMS and sign in with any user with non admin credentials. 
2. Now send a get request at the following endpoint "/api/mobile/v1/user_sites/"
3. Expect the API to return the site data for all sites for all edx organisations that the user is linked to.
4. If site data not returned properly then check failed.