### PR TITLE
Fix: Filter Courses against edx-org

### DIFF
--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -8,10 +8,8 @@ to decide whether to check course creator role, and other such functions.
 
 from ccx_keys.locator import CCXBlockUsageLocator, CCXLocator
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from opaque_keys.edx.locator import LibraryLocator
-
-from organizations.models import Organization
 
 from student.roles import (
     CourseBetaTesterRole,
@@ -81,12 +79,6 @@ def get_user_permissions(user, course_key, org=None):
     """
     if org is None:
         org = course_key.org
-        organization = Organization.objects.get(short_name=org)
-        try:
-            edly_sub_org = organization.edx_organizations.first().slug
-        except ObjectDoesNotExist:
-            edly_sub_org = None
-
         course_key = course_key.for_branch(None)
     else:
         assert course_key is None
@@ -99,7 +91,7 @@ def get_user_permissions(user, course_key, org=None):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
-    if course_key and user_has_role(user, GlobalCourseCreatorRole(edly_sub_org)):
+    if course_key and user_has_role(user, GlobalCourseCreatorRole(org)):
         return all_perms
     # Staff have all permissions except EDIT_ROLES:
     if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -21,7 +21,7 @@ from six.moves import map
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.core.djangoapps.schedules.utils import reset_self_paced_schedule
-from openedx.features.edly.utils import get_edly_sub_org_from_cookie
+from openedx.features.edly.utils import get_edx_org_from_cookie
 
 import track.views
 from edxmako.shortcuts import render_to_response
@@ -75,8 +75,9 @@ def require_global_staff(func):
     @wraps(func)
     def wrapped(request, *args, **kwargs):
         edly_user_info_cookie = request.COOKIES.get(settings.EDLY_USER_INFO_COOKIE_NAME, None) if request else None
-        edly_sub_org = get_edly_sub_org_from_cookie(edly_user_info_cookie)
-        if GlobalStaff().has_user(request.user) or GlobalCourseCreatorRole(edly_sub_org).has_user(request.user):
+        edx_orgs = get_edx_org_from_cookie(edly_user_info_cookie)
+        edx_org = edx_orgs[0] if len(edx_orgs) > 0 else None
+        if GlobalStaff().has_user(request.user) or GlobalCourseCreatorRole(edx_org).has_user(request.user):
             return func(request, *args, **kwargs)
         else:
             return HttpResponseForbidden(


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
This PR fixes the issue where the course was filtered on the base of edly-sub-org. We recently made the change and now the GlobalCourseCreator role is created against the edx-org not on edly-sub-org https://github.com/edly-io/edx-platform/pull/286