### PR TITLE
Fix invalid certificate header logo src - EDLY-4110

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -47,7 +47,10 @@ from openedx.core.djangoapps.certificates.api import certificates_viewable_for_c
 from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
-from openedx.features.edly.utils import get_current_site_invalid_certificate_context
+from openedx.features.edly.utils import (
+    get_current_site_invalid_certificate_context,
+    get_logo_from_current_site_configurations
+)
 from student.models import LinkedInAddToProfileConfiguration
 from util import organizations_helpers as organization_api
 from util.date_utils import strftime_localized
@@ -686,6 +689,7 @@ def _render_invalid_certificate(request, course_id, platform_name, configuration
     # Add certificate header/footer data to current context
     context.update(get_certificate_header_context(is_secure=request.is_secure()))
     context.update(get_certificate_footer_context())
+    context.update(get_logo_from_current_site_configurations())
     return render_to_response(cert_path, context)
 
 

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -373,6 +373,22 @@ def get_current_site_invalid_certificate_context(default_html_certificate_config
     context['company_tos_url'] = get_tos_and_honor_code_url()
     return context
 
+
+def get_logo_from_current_site_configurations():
+    """
+    Gets the "logo" value in "BRANDING" from current site configurations.
+
+    Returns:
+        dict: Context data.
+    """
+    context = dict()
+    current_site_configuration = get_current_site_configuration()
+    if current_site_configuration:
+        context['logo_src'] = current_site_configuration.get_value('BRANDING', {}).get('logo', '')
+
+    return context
+
+
 def clean_django_settings_override(django_settings_override):
     """
     Enforce only allowed django settings to be overridden.


### PR DESCRIPTION
**Description:** This PR fixes the issue of static url being fetched for logo src in case of invalid certificate.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-4110

**Visible Changes:**
<img width="1359" alt="Screenshot 2021-12-17 at 6 21 26 PM" src="https://user-images.githubusercontent.com/68893403/146550902-0bf5be5b-7af6-4426-8081-013022bba7a5.png">


<img width="1382" alt="Screenshot 2021-12-17 at 6 18 41 PM" src="https://user-images.githubusercontent.com/68893403/146550806-d5c04276-58a3-42a3-8336-050b44a8883a.png">
