### PR TITLE
Changing Organisation field in Course Rerun in Studio to readonly

### DIFF
--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -82,7 +82,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                     </li>
                     <li class="field text required">
                       <label for="rerun-course-org">${_("Organization")}</label>
-                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" value="${source_course_key.org}" placeholder="${_('e.g. UniversityX or OrganizationX')}" />
+                      <input class="rerun-course-org" id="rerun-course-org" type="text" name="rerun-course-org" aria-required="true" value="${source_course_key.org}" placeholder="${_('e.g. UniversityX or OrganizationX')}" readonly="readonly" />
                       <span class="tip">
                         ${_("The name of the organization sponsoring the new course. (This name is often the same as the original organization name.)")}
                         <strong class="tip-note" class="tip-note">${_("Note: No spaces or special characters are allowed.")}</strong>


### PR DESCRIPTION
**Description:** Changing the Organisation field in Course Rerun to Read only.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-4124

**Testing instructions:**

1. Open Studio and click on course re run
2. The organisation field should not be editable
3. If editable instead - check failed.

**Merge checklist:**

- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
