### PR TITLE
Fix default language on email during registration

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -216,6 +216,11 @@ def create_account_with_params(request, params):
     create_user_link_with_edly_sub_organization(request, user)
     user = create_learner_link_with_permission_groups(user)
 
+    # Sites using multiple languages need to record the language used during registration.
+    # If not, compose_and_send_activation_email will be sent in site's default language only.
+    create_or_set_user_attribute_created_on_site(user, request.site)
+    preferences_api.set_user_preference(user, LANGUAGE_KEY, get_language())
+
     # Check if system is configured to skip activation email for the current user.
     skip_email = _skip_activation_email(
         user, running_pipeline, third_party_provider,
@@ -225,11 +230,6 @@ def create_account_with_params(request, params):
         registration.activate()
     else:
         compose_and_send_activation_email(user, profile, registration)
-
-    # Perform operations that are non-critical parts of account creation
-    create_or_set_user_attribute_created_on_site(user, request.site)
-
-    preferences_api.set_user_preference(user, LANGUAGE_KEY, get_language())
 
     if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
         try:


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR fixes the issue where the registration emails always send in default language. The solution is cherry picked from the edx Master https://github.com/edx/edx-platform/commit/36db87e7348b28b920cb0d981bb68fb0d99fedcf

Jira Ticket: https://edlyio.atlassian.net/browse/EDLY-4184