### PR TITLE
Update enrollment api to restrict cross-site users - EDLY-4225

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -747,6 +747,7 @@ EDLY_PANEL_ADMIN_USERS_GROUP = 'Edly Panel Admin Users'
 EDLY_PANEL_RESTRICTED_USERS_GROUP = 'Edly Panel Restricted Users'
 EDLY_WP_ADMIN_USERS_GROUP = 'WordPress Edly Admin Users'
 EDLY_WP_SUBSCRIBER_USERS_GROUP = 'WordPress Subscriber Users'
+EDLY_API_USERS_GROUP = 'Edly API Users'
 
 
 EDLY_USER_ROLES = {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1614,6 +1614,7 @@ EDLY_PANEL_ADMIN_USERS_GROUP = 'Edly Panel Admin Users'
 EDLY_PANEL_RESTRICTED_USERS_GROUP = 'Edly Panel Restricted Users'
 EDLY_WP_ADMIN_USERS_GROUP = 'WordPress Edly Admin Users'
 EDLY_WP_SUBSCRIBER_USERS_GROUP = 'WordPress Subscriber Users'
+EDLY_API_USERS_GROUP = 'Edly API Users'
 
 EDLY_USER_ROLES = {
     'panel_restricted': EDLY_PANEL_RESTRICTED_USERS_GROUP,


### PR DESCRIPTION
**Description:** This PR adds restriction to the `enrollment` api to check if the user being enrolled doesn't belong to the `EdlySubOrganization` as the request site sub org then raise `ObjectDoesNotExist` exception.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-4225