### PR TITLE
Discovery returns a 404 to learners for unreleased content and LMS sh…

### DIFF
--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -472,7 +472,7 @@ class CoursewareIndex(View):
 
         if COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id):
             course_block_tree = get_course_outline_block_tree(
-                request, six.text_type(self.course.id), request.user, allow_start_dates_in_future=True
+                request, six.text_type(self.course.id), request.user
             )
             courseware_context['accordion'] = render_accordion(
                 self.request,


### PR DESCRIPTION
**Description**
Discovery returns a 404 to learners for unreleased course content and LMS shows unreleased content

**JIRA**
https://edlyio.atlassian.net/browse/EDLY-4417