### PR TITLE
[New Xblock] Enable Image Explorer on Studio

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -247,6 +247,7 @@ webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
+git+https://github.com/openedx/xblock-image-explorer.git@v2.0#egg=exblock-image-explorer==v2.0 # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
 xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.3.1             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils


### PR DESCRIPTION
**Description**
Adding new Xblock to Studio for Image Explorer, Adding the xblock in requirements.

Steps to enabling the Xblock:
1. From the main page of a specific course, navigate to Settings -> Advanced Settings from the top menu.
2. Check for the advanced_modules policy key, and add "image-explorer" to the policy value list.
3. Click the "Save changes" button.

![image](https://user-images.githubusercontent.com/86109301/168100318-1b804d99-37cc-4ac9-b878-42a63e380561.png)

**JIRA**
https://edlyio.atlassian.net/browse/EDLY-4494
