### PR TITLE
Faateh/Edly-4747 - Fix NaN unit in timed exams with past due dates

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -62,7 +62,10 @@
             this.keydownHandler($(element).find('#sequence-list .tab'));
             this.base_page_title = ($('title').data('base-title') || '').trim();
             this.bind();
-            this.render(parseInt(this.el.data('position'), 10));
+            this.render(parseInt(this.el.data('position')), 10);
+            if (!(this.el.data('position'))) {
+                $('#seq-end-element-wrapper').hide()
+            }
         }
 
         Sequence.prototype.$ = function(selector) {


### PR DESCRIPTION
**Description:** The timed exams were previously being shown as Unit NaN in the LMS. This bug is now fixed and unit no is hidden being irrelevant when the exam is past the due date. The display.js responsible for rendering this unit was updated.

**Dependencies:** Another PR from edx-platform is a dependency for this feature to work, link [here](https://github.com/edly-io/edly-edx-themes/pull/370)

**Merge deadline:** N/A

**Installation instructions:** N/A

**Testing instructions:**

1. Create a course with timed exams enabled and create a section with the past due date.
2. Attempt it from LMS.
3. Expected: It should not show any unit number for the expired timed exam.
4. If it is not working as expected, the feature might be failed.

Screenshots:
- Previously, with bug:
<img width="1440" alt="Screenshot 2022-09-29 at 2 23 44 PM" src="https://user-images.githubusercontent.com/54814772/194045014-78422437-2add-44e5-9ad4-e025c71f8ed4.png">
- Now, bug fixed:
<img width="1440" alt="Screenshot 2022-10-05 at 3 49 45 PM" src="https://user-images.githubusercontent.com/54814772/194045056-a2744738-42ec-4bf8-b655-ff1ecd316444.png">