### PR TITLE
Added current_site parameter in user_can_login_on_requested_edly_organization()

### DIFF
--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -303,7 +303,7 @@ def edly_panel_user_has_edly_org_access(request):
     ).exists()
 
 
-def user_can_login_on_requested_edly_organization(request, user):
+def user_can_login_on_requested_edly_organization(request, user, current_site=None):
     """
     Check if user can login on the requested URL site.
 
@@ -322,7 +322,9 @@ def user_can_login_on_requested_edly_organization(request, user):
         bool: Returns True if User can login, False otherwise
     """
 
-    current_site = request.site
+    if not current_site:
+        current_site = request.site
+
     try:
         edly_sub_org = EdlySubOrganization.objects.get(
             Q(lms_site=current_site) |


### PR DESCRIPTION
**Description:** 
This PR adds a `current_site` parameter with default value `None` in the method edly-setup/edly/src/edly-panel-edx-app/edly_panel_app/api/v1/helpers.py/user_can_login_on_requested_edly_organization method

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-5120

**Testing instructions:**

**Merge checklist:**

- [ ] All reviewers approved
- <del>[ ] CI build is green
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are (reasonably) squashed
- [ ] Translations are updated

**Post merge:**
- [ ] Delete working branch (if not needed anymore)


**Note:** Please add screenshots for any viewable change.
