### PR TITLE
Enabling few advanced xblocks by default for free trial EDLY-5504

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1791,6 +1791,26 @@ ADVANCED_PROBLEM_TYPES = [
     {
         'component': 'edlyrating',
         'boilerplate_name': None
+    },
+    {
+        'component': 'lti_consumer',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'kwl',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'annotatable',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'google-document',
+        'boilerplate_name': None
+    },
+    {
+        'component': 'library_content',
+        'boilerplate_name': None
     }
 ]
 


### PR DESCRIPTION
Description:
Enabling a few blocks by default so that free trial learners can explore that functionality

JIRA:
[EDLY-5504](https://edlyio.atlassian.net/browse/EDLY-5504)

[EDLY-5504]: https://edlyio.atlassian.net/browse/EDLY-5504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ