### PR TITLE
Update course name on rerun course creation EDLY-6016

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1044,6 +1044,10 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     else:
         rerun_course_task(*args)
 
+    course_module = get_course_and_check_access(destination_course_key, user)
+    metadata = {u'display_name': fields['display_name']}
+    CourseMetadata.update_from_dict(metadata, course_module, user)
+
     return destination_course_key
 
 


### PR DESCRIPTION
## Description:
**[WRI - UrbanShift] Incorrect Course Name on Re-Run When Viewed Live**
The customer WRI is extensively using the Re-Run features to copy their English courses for translation. When created in Re-Run, the course titles are changed. When Viewed Live, only the original course title is being shown. 

## Jira:
https://edlyio.atlassian.net/browse/EDLY-6016