### PR TITLE
lxml verison bump EDLY-6057

### DIFF
--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -14,7 +14,7 @@ cycler==0.10.0            # via matplotlib
 decorator==4.4.2          # via networkx
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt, nltk
 kiwisolver==1.1.0         # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
-lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
+lxml==4.9.3               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
 markupsafe==1.1.1         # via chem
 matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in
 mpmath==1.1.0             # via sympy

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -8,7 +8,7 @@ cffi==1.14.3              # via cryptography
 click==7.1.2              # via nltk
 cryptography==3.2.1       # via -r requirements/edx-sandbox/shared.in
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, nltk
-lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
+lxml==4.9.3               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.in
 pycparser==2.20           # via cffi
 regex==2020.11.11         # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -147,7 +147,7 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
 lti-consumer-xblock==2.4  # via -r requirements/edx/base.in
-lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
+lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-wiki, staff-graded-xblock, xblock-poll

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -174,7 +174,7 @@ lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bo
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
 lti-consumer-xblock==2.4  # via -r requirements/edx/testing.txt
-lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
+lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt
 mako==1.1.3               # via -r requirements/edx/testing.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -169,7 +169,7 @@ lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-c
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
 lti-consumer-xblock==2.4  # via -r requirements/edx/base.txt
-lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
+lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.1.3               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-wiki, staff-graded-xblock, xblock-poll


### PR DESCRIPTION
### Description:
lxml version bump from 4.5.0 to 4.9.3

### Jira:
https://edlyio.atlassian.net/browse/EDLY-6057
