### PR TITLE
 lti-consumer-xblock version bump

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -146,7 +146,7 @@ laboratory==1.0.2         # via -r requirements/edx/base.in
 lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-lti-consumer-xblock==2.4  # via -r requirements/edx/base.in
+lti-consumer-xblock==4.3  # via -r requirements/edx/base.in
 lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -173,7 +173,7 @@ lazy-object-proxy==1.4.3  # via -r requirements/edx/testing.txt, astroid
 lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
-lti-consumer-xblock==2.4  # via -r requirements/edx/testing.txt
+lti-consumer-xblock==4.3  # via -r requirements/edx/testing.txt
 lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -168,7 +168,7 @@ lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
-lti-consumer-xblock==2.4  # via -r requirements/edx/base.txt
+lti-consumer-xblock==4.3  # via -r requirements/edx/base.txt
 lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.1.3               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils


### PR DESCRIPTION
Description:

Changing the version of lti-consumer-xblock from 2.4 to 4.3.