### PR TITLE
Update: add redirections in middleware for deactivate accounts

### DIFF
--- a/lms/templates/account_deactivated.html
+++ b/lms/templates/account_deactivated.html
@@ -1,0 +1,4 @@
+<main>
+YOUR ACCOUNT IS DEACTIVATED
+</main>
+

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -199,6 +199,7 @@ urlpatterns = [
     url(r'^api/discounts/', include(('openedx.features.discounts.urls', 'openedx.features.discounts'),
                                     namespace='api_discounts')),
 
+    url(r'', include(('openedx.features.edly.urls', 'openedx.features.edly'), namespace='edly_app_urls')),
     url(r'^api/v1/courses/', include('openedx.features.edly.api.urls')),
 ]
 

--- a/openedx/features/edly/urls.py
+++ b/openedx/features/edly/urls.py
@@ -1,0 +1,11 @@
+"""
+URLs Edly app views.
+"""
+
+from django.conf.urls import url
+
+from openedx.features.edly.views import account_deactivated_view
+
+urlpatterns = [
+    url('account_deactivated/', account_deactivated_view, name='account_deactivated_view'),
+]

--- a/openedx/features/edly/views.py
+++ b/openedx/features/edly/views.py
@@ -1,0 +1,9 @@
+"""
+Views related to the Edly app feature.
+"""
+
+from django.shortcuts import render
+
+
+def account_deactivated_view(request):
+    return render(request=request, template_name="account_deactivated.html")


### PR DESCRIPTION
Description
Handles redirections in LMS and Studio as follows user type logged in:

Learner: Redirect to account deactivated page
Panel Admin: Redirect to panel frontend

Jira Ticket
https://edlyio.atlassian.net/browse/EDLY-5478