### PR TITLE
Prevent sending password reset emails to inactive users EDLY-6018

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -205,7 +205,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
 
         if not self.users_cache:
             raise forms.ValidationError(self.error_messages['unknown'])
-        if any((user.password.startswith(UNUSABLE_PASSWORD_PREFIX))
+        if any((user.password.startswith(UNUSABLE_PASSWORD_PREFIX) or not user.is_active) 
                for user in self.users_cache):
             raise forms.ValidationError(self.error_messages['unusable'])
         return email


### PR DESCRIPTION
**Descrption:**
Reset Password email is received at email associated with Deactivated Account.

**Jira:**
https://edlyio.atlassian.net/browse/EDLY-6018