### PR TITLE
fix: Update course name in rerun task EDLY-6115

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -135,6 +135,13 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
 
         org_data = get_organization_by_short_name(source_course_key.org)
         add_organization_course(org_data, destination_course_key)
+        
+        if fields and 'display_name' in fields:
+            user = User.objects.get(id=user_id)
+            course_module = modulestore().get_course(destination_course_key, depth=0)
+            metadata = {u'display_name': fields['display_name']}
+            CourseMetadata.update_from_dict(metadata, course_module, user)
+
         return "succeeded"
 
     except DuplicateCourseError:

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1025,10 +1025,6 @@ def rerun_course(user, source_course_key, org, number, run, fields, background=T
     else:
         rerun_course_task(*args)
 
-    course_module = get_course_and_check_access(destination_course_key, user)
-    metadata = {u'display_name': fields['display_name']}
-    CourseMetadata.update_from_dict(metadata, course_module, user)
-
     return destination_course_key
 
 


### PR DESCRIPTION
## Description

This PR is to move the display name fix inside the course rerun task to avoid issues.

## Jira
https://edlyio.atlassian.net/browse/EDLY-6115