### PR TITLE
Fix: Fix message for already login user in reset email

### DIFF
--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -32,6 +32,13 @@ from openedx.core.djangolib.markup import HTML, Text
                 'errorMessage': js_escaped_string(err_msg) if err_msg else '',
             },
         )}
+    % elif  user_exist:
+    <div class="status submission-success">
+        <h4 class="message-title">${_("User is already logged in")}</h4>
+        <ul class="message-copy">
+            You are already logged in. Please logout and try again or change browser.<br/>
+        </ul>
+    </div>  
     % else:
         <div class="status submission-error">
             <h4 class="message-title">${_("Invalid Password Reset Link")}</h4>

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -387,7 +387,17 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
         try:
             self.uid_int = base36_to_int(self.uidb36)
             if request.user.is_authenticated and request.user.id != self.uid_int:
-                raise Http404
+                context = {
+                    'validlink': False,
+                    'user_exist': True,
+                    'form': None,
+                    'title': _('password reset'),
+                    'err_msg': _('User already login on the current browser window'),
+                }
+                return TemplateResponse(
+                    request, 'registration/password_reset_confirm.html', context
+                )
+            
             self.user = User.objects.get(id=self.uid_int)
         except (ValueError, User.DoesNotExist):
             # if there's any error getting a user, just let django's


### PR DESCRIPTION
This PR update the reset email template incase the user is already login. 

## Steps to reproduce:

- Generate a password reset link for a user from the Edly Panel or from the Forgot Password page
- While already logged in/authenticated click on the link in the password reset email.

## Expected Behaviour:
User should be shown a message that he is already login on current browser. 

## Jira ticket

https://edlyio.atlassian.net/browse/EDLY-5204?atlOrigin=eyJpIjoiODFhZjJlZDc2Yzg3NDY1Y2FiYjE1N2FhY2I2M2E1ODYiLCJwIjoiaiJ9


