### PR TITLE
Feat: add admin model for image assets

### DIFF
--- a/openedx/features/sdaia_features/__init__.py
+++ b/openedx/features/sdaia_features/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "openedx.features.sdaia_features.apps.SdaiaFeaturesConfig"

--- a/openedx/features/sdaia_features/admin.py
+++ b/openedx/features/sdaia_features/admin.py
@@ -1,0 +1,16 @@
+from django.contrib import admin
+from django.utils.safestring import mark_safe
+
+from .models import ImageAsset
+
+
+class ImageAssetAdmin(admin.ModelAdmin):
+    list_display = ("title", "image_display", "description")
+
+    def image_display(self, obj):
+        return mark_safe(f'<img src="{obj.image.url}" width="50" height="50" />')
+
+    image_display.short_description = "Image"
+
+
+admin.site.register(ImageAsset, ImageAssetAdmin)

--- a/openedx/features/sdaia_features/apps.py
+++ b/openedx/features/sdaia_features/apps.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.apps import AppConfig
+
+
+class SdaiaFeaturesConfig(AppConfig):
+    name = "openedx.features.sdaia_features"

--- a/openedx/features/sdaia_features/migrations/0001_initial.py
+++ b/openedx/features/sdaia_features/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+from django.conf import settings
+import storages.backends.s3
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ImageAsset',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=255)),
+                ('image', models.ImageField(storage=storages.backends.s3.S3Storage(bucket_name=settings.ASSET_BUCKET), upload_to='image_assets/')),
+                ('description', models.TextField(blank=True, null=True)),
+            ],
+        ),
+    ]

--- a/openedx/features/sdaia_features/models.py
+++ b/openedx/features/sdaia_features/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.conf import settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class ImageAsset(models.Model):
+    title = models.CharField(max_length=255)
+    image = models.ImageField(
+        upload_to="image_assets/",
+        storage=S3Boto3Storage(bucket_name=settings.ASSET_BUCKET),
+    )
+    description = models.TextField(blank=True, null=True)
+
+    def __str__(self):
+        return self.title


### PR DESCRIPTION
1. Add admin model for image assets.  
2. Upload image assets to public storage bucket.

OCI Object Storage is full compatible with AWS S3 API

- https://medium.com/oracledevs/use-aws-python-sdk-to-upload-files-to-oracle-cloud-infrastructure-object-storage-b623e5681412
- https://django-storages.readthedocs.io/en/latest/backends/oracle-cloud.html
