### PR TITLE
added hubspot events in studio

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -82,6 +82,7 @@ from common.djangoapps.util.organizations_helpers import (
 )
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
 from common.djangoapps.xblock_django.api import deprecated_xblocks
+from edly_panel_app.api.v1.constants import DESTINATION_COURSE_ID_PATTERN
 from xmodule.contentstore.content import StaticContent
 from xmodule.course_module import DEFAULT_START_DATE, CourseFields
 from xmodule.error_module import ErrorDescriptor
@@ -624,7 +625,12 @@ def course_listing(request):
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
 
+    site_config = configuration_helpers.get_current_site_configuration()
+    tracking_api_url = f"{site_config.get_value('PANEL_NOTIFICATIONS_BASE_URL')}/api/v1/tracking_events/"
+
     return render_to_response(u'index.html', {
+        u'default_course_id': DESTINATION_COURSE_ID_PATTERN.format(org[0]),
+        u'tracking_api_url': tracking_api_url,
         u'courses': active_courses,
         u'archived_courses': archived_courses,
         u'in_process_course_actions': in_process_course_actions,

--- a/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
+++ b/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
@@ -26,11 +26,28 @@ export function CourseOrLibraryListing(props) {
     const items = props.items;
     const can_archive = props.can_archive;
 
+    const sendTracking = () => {
+        const url = props.tracking_api_url;
+        const requestData = { event_data: { has_viewed_course: "true" } };
+        fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(requestData),
+        });
+    };
+
     return (
         <div>
             <ul className="list-courses">
                 {items.map((item, i) => (
-                    <li key={i} className="course-item" data-course-key={item.course_key}>
+                    <li
+                        key={i}
+                        className="course-item"
+                        data-course-key={item.course_key}
+                        onClick={props.default_course_id === item.course_key ? sendTracking : undefined}
+                    >
                         <a className={linkClass} href={item.url}>
                             <h3 className="course-title" id={`title-${idBase}-${i}`}>
                                 {item.display_name}

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -124,15 +124,15 @@ from openedx.core.djangolib.js_utils import (
             <input type="hidden" value="${allow_unicode_course_id}" class="allow-unicode-course-id" />
             <input
               type="submit"
-              value="${_('Create')}" 
+              value="${_('Create')}"
               class="action action-primary new-course-save"
               onclick="mixpanel.track('create_course',
-                    {
-                        'service': 'studio',
-                        'screen_name': 'studio_home',
-                        'organization': '${platform_name}',
-                    }
-                );"
+                  {
+                    'service': 'studio',
+                    'screen_name': 'studio_home',
+                    'organization': '${platform_name}',
+                  }
+              ); sendTracking({'has_created_course':'true'});"
             />
             <input type="button" value="${_('Cancel')}" class="action action-secondary action-cancel new-course-cancel" />
           </div>
@@ -354,6 +354,8 @@ from openedx.core.djangolib.js_utils import (
             'idBase': 'course',
             'allowReruns': allow_course_reruns and rerun_creator_status and course_creator_status=='granted',
             'can_archive': user.is_staff or course_creator_status=='granted',
+            'default_course_id': default_course_id,
+            'tracking_api_url': tracking_api_url,
           }
         )}
       </div>
@@ -607,4 +609,19 @@ from openedx.core.djangolib.js_utils import (
 
   %endif
 </div>
+
+<script>
+    function sendTracking(data) {
+        const url = "${tracking_api_url}";
+        requestData = { event_data: data }
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(requestData)
+        })
+    }
+</script>
+
 </%block>


### PR DESCRIPTION
This PR adds hubspot events tracking in studio. On 'save' button in course creation and on clicking the default course in studio an api call to panel backend is sent which update hubspot deal accordingly

JIRA: https://edlyio.atlassian.net/browse/EDLY-6247