### PR TITLE
lti-consumer-xblock version bump EDLY-6539

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -23,11 +23,11 @@ amqp==2.6.1               # via kombu
 analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==8.0.0          # via edx-tincan-py35
 appdirs==1.4.4            # via fs
-attrs==20.3.0             # via -r requirements/edx/base.in, edx-ace
+attrs==21.3.0             # via -r requirements/edx/base.in, edx-ace
 babel==2.8.1              # via -r requirements/edx/base.in, enmerkar, enmerkar-underscore
 beautifulsoup4==4.9.3     # via pynliner
 billiard==3.6.3.0         # via celery
-bleach==3.2.1             # via -r requirements/edx/base.in, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-poll
+bleach==6.1.0             # via -r requirements/edx/base.in, django-wiki, edx-enterprise, lti-consumer-xblock, ora2, xblock-poll
 boto3==1.4.8              # via -r requirements/edx/base.in, django-ses, fs-s3fs, ora2
 boto==2.39.0              # via -r requirements/edx/base.in, edxval
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
@@ -146,7 +146,6 @@ laboratory==1.0.2         # via -r requirements/edx/base.in
 lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-lti-consumer-xblock==3.3  # via -r requirements/edx/base.in
 lxml==4.9.3               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -267,7 +266,7 @@ git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblo
 -e git+https://github.com/PakistanX/xblock-image-explorer.git@v2.1#egg=xblock-image-explorer==v2.1
 -e git+https://github.com/edly-io/carousel-xblock.git@v1.0.0#egg=edly-carousel-xblock
 -e git+https://github.com/edly-io/zoom-meeting-xblock.git@v-1.0.0#egg=zoom_meeting_xblock==v-1.0.0
-
+-e git+https://github.com/edly-io/xblock-lti-consumer.git@edly-v8.0.0#egg=lti-consumer-xblock
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
 


### PR DESCRIPTION
## Description

Changing the version of lti-consumer-xblock to v8.0.0.
check for staff user based on course

## Jira
https://edlyio.atlassian.net/browse/EDLY-6539

## Related PR
https://github.com/edly-io/xblock-lti-consumer/pull/2