### PR TITLE
video module transcripts fix

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1377,14 +1377,11 @@ YOUTUBE = {
     # URL to get YouTube metadata
     'METADATA_URL': 'https://www.googleapis.com/youtube/v3/videos',
 
-    # Current youtube api for requesting transcripts.
-    # For example: http://video.google.com/timedtext?lang=en&v=j_jEn79vS3g.
-    'TEXT_API': {
-        'url': 'video.google.com/timedtext',
-        'params': {
-            'lang': 'en',
-            'v': 'set_youtube_id_of_11_symbols_here',
-        },
+    # Web page mechanism for scraping transcript information from youtube video pages
+    'TRANSCRIPTS': {
+        'CAPTION_TRACKS_REGEX': r"captionTracks\"\:\[(?P<caption_tracks>[^\]]+)",
+        'YOUTUBE_URL_BASE': 'https://www.youtube.com/watch?v=',
+        'ALLOWED_LANGUAGE_CODES': ["en", "en-US", "en-GB"],
     },
 
     'IMAGE_API': 'http://img.youtube.com/vi/{youtube_id}/0.jpg',  # /maxresdefault.jpg for 1920*1080


### PR DESCRIPTION
This PR fixes the video module so it can fetch transcripts from youtube and add to videos. It does so by obtaining some code from upstream openedx repo.

How to test:
1- Go to course
2- Add video module
3- click edit on video module unit
4- click import transcript from youtube

JIRA: https://edlyio.atlassian.net/browse/EDLY-6729

Video:


https://github.com/edly-io/edx-platform/assets/109604645/61328ed3-57e0-4d94-ba81-85b1588d5f8e



