### PR TITLE
refactor: add two small fixes in chatly cookie setting

### DIFF
--- a/openedx/features/edly/chatly_helpers.py
+++ b/openedx/features/edly/chatly_helpers.py
@@ -35,14 +35,15 @@ def get_chatly_token_from_cookie(request):
         chatly_token: string
 
     """
+    eval_string = "None"
     if CHATLY_COOKIE_NAME in request.COOKIES:
         chatly_token = request.COOKIES[CHATLY_COOKIE_NAME]
-        eval_string = "None"
     else:
         chatly_token = obtain_token_from_chatly()
-        eval_string = (
-            f'response.set_cookie({CHATLY_COOKIE_NAME}, chatly_token, max_age=604600)'
-        )
+        if chatly_token:
+            eval_string = (
+                f'response.set_cookie("{CHATLY_COOKIE_NAME}", chatly_token, max_age=604600)'
+            )
 
     return eval_string, chatly_token
 


### PR DESCRIPTION
This PR adds an issue which occurred in setting of chatly cookie of setting variables are missing from environment. Namely, it fixes the eval string to include quotes around constant and it does not set cookie if chatly token value is empty string.