### PR TITLE
cherry-pick: allow importing courses into Studio with empty libraries

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -833,7 +833,7 @@ def _update_and_import_module(
     if block.location.block_type == 'library_content':
         # If library exists, update source_library_version and children
         # according to this existing library and library content block.
-        if store.get_library(block.source_library_key):
+        if block.source_library_id and store.get_library(block.source_library_key):
             # If the library content block is already in the course, then don't
             # refresh the children when we re-import it. This lets us address
             # TNL-7507 (Randomized Content Block Settings Lost in Course Import)


### PR DESCRIPTION
## Description

If a content library xblock does not specify a library id, we previously would error out when importing, due to some cleanup code that wasn't accounting for this case.

This PR cherry-picks this [PR](https://github.com/openedx/edx-platform/pull/28388).

## Jira
https://edlyio.atlassian.net/browse/EDLY-6622