### PR TITLE
feat: Allow forum app to use Forum V2 APIs

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/settings.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/settings.py
@@ -1,17 +1,18 @@
 # lint-amnesty, pylint: disable=cyclic-import, missing-module-docstring
 from django.conf import settings
 
+# FORUM V1 SERVICE HOST
 if hasattr(settings, "COMMENTS_SERVICE_URL"):
-    SERVICE_HOST = settings.COMMENTS_SERVICE_URL
+    COMMENTS_SERVICE_SERVICE_HOST = settings.COMMENTS_SERVICE_URL
 else:
-    SERVICE_HOST = 'http://localhost:4567'
+    COMMENTS_SERVICE_SERVICE_HOST = "http://localhost:4567"
 
-PREFIX = SERVICE_HOST + '/api/v1'
+COMMENTS_SERVICE_PREFIX = COMMENTS_SERVICE_SERVICE_HOST + "/api/v1"
 
-# V2 url support for differential logging
-if hasattr(settings, "COMMENTS_SERVICE_V2_URL"):
-    SERVICE_HOST_V2 = settings.COMMENTS_SERVICE_V2_URL
+
+if hasattr(settings, "FORUM_V2_SERVICE_URL"):
+    SERVICE_HOST = settings.FORUM_V2_SERVICE_URL
 else:
-    SERVICE_HOST_V2 = 'http://localhost:8000'
+    SERVICE_HOST = "http://localhost:8000"
 
-PREFIX_V2 = SERVICE_HOST_V2 + '/forum/forum_proxy/api/v1'
+PREFIX = SERVICE_HOST + "/forum/api/v2"


### PR DESCRIPTION
## Description

Added a setting FORUM_V2_REGEXS. It contains regex patterns for matching ForumV2 app URLs. The application will use the ForumV2 APIs if a ForumV1 URL matches any of these regex patterns. This setting is intended to help route traffic to the appropriate version of the Forum API based on the structure of the URL.
