### PR TITLE
Fix: Add language in the course listing API for syncing with dataloader

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -77,6 +77,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     mobile_available = serializers.BooleanField()
     hidden = serializers.SerializerMethodField()
     invitation_only = serializers.BooleanField()
+    language = serializers.CharField()
 
     # 'course_id' is a deprecated field, please use 'id' instead.
     course_id = serializers.CharField(source='id', read_only=True)

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -303,7 +303,8 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
                 "org": "edX",
                 "start": "2015-07-17T12:00:00Z",
                 "start_display": "July 17, 2015",
-                "start_type": "timestamp"
+                "start_type": "timestamp", 
+                language: null or 'en' # language code
               }
             ]
     """

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -226,8 +226,7 @@ class CourseOverview(TimeStampedModel):
         course_overview.course_video_url = CourseDetails.fetch_video_url(course.id)
         course_overview.self_paced = course.self_paced
 
-        if not CatalogIntegration.is_enabled():
-            course_overview.language = course.language
+        course_overview.language = course.language
 
         return course_overview
 


### PR DESCRIPTION
Add the language Field value of the course in the course API for discovery dataloader. 