### PR TITLE
H5P xblock version bump

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -126,7 +126,8 @@ geoip2==3.0.0             # via -c requirements/edx/../constraints.txt, -r requi
 glob2==0.7                # via -r requirements/edx/base.in
 gunicorn==20.0.4          # via -r requirements/edx/base.in
 help-tokens==1.1.2        # via -r requirements/edx/base.in
-h5p-xblock==0.2.2
+importlib-resources==3.2.1
+h5p-xblock==0.2.14
 instruqt-xblock==0.2.2
 html5lib==1.1             # via -r requirements/edx/base.in, ora2
 icalendar==4.0.7          # via -r requirements/edx/base.in


### PR DESCRIPTION
**Bump H5P XBlock Version to `0.2.14` to Resolve File Duplication Issue**

This PR upgrades the H5P XBlock to version `0.2.14`, addressing the issue where multiple H5P blocks within a single unit display the same file (the first added one) across all blocks.

Additionally, `importlib-resources` has been added as a requirement, as it's a necessary dependency for the H5P XBlock on Python versions below 3.9.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-6895