### PR TITLE
EDLY-6859: Fix set password screen shows reset password text

### DIFF
--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -58,7 +58,7 @@ urlpatterns = [
     # Password reset api views.
     url(r'^password_reset/$', password_reset.password_reset, name='password_reset'),
     url(
-        r'^password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
+        r'^password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+?)(?:/(?P<method>new_password|reset_password))?/?$',
         PasswordResetConfirmWrapper.as_view(),
         name='password_reset_confirm',
     ),

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -523,6 +523,7 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
     def dispatch(self, *args, **kwargs):
         self.uidb36 = kwargs.get('uidb36')
         self.token = kwargs.get('token')
+        self.is_new_user = kwargs.get('method', None) == 'new_password'
         self.uidb64 = _uidb36_to_uidb64(self.uidb36)
 
         # User can not get this link unless account recovery feature is enabled.
@@ -553,6 +554,9 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
                 if response_was_successful and not self.user.is_active:
                     self.user.is_active = True
                     self.user.save()
+
+                response.context_data['is_new_user'] = self.is_new_user
+
             return response
 
 


### PR DESCRIPTION
**Description:** 
When a new user account is created, set password screen shows `reset your password` message. This PR updates the text.

**JIRA:** 
https://edlyio.atlassian.net/browse/EDLY-6859
