### PR TITLE
fix: xblock-poll's celery tasks were not registered (#28019)

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2402,6 +2402,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+CELERY_IMPORTS = (
+    # Since xblock-poll is not a Django app, and XBlocks don't get auto-imported
+    # by celery workers, its tasks will not get auto-discovered:
+    'poll.tasks',
+)
+
 # Celery beat configuration
 
 CELERYBEAT_SCHEDULER = 'celery.beat:PersistentScheduler'


### PR DESCRIPTION
## Description: 
This PR cherry-picks an [upstream commit ](https://github.com/openedx/edx-platform/pull/28019) to fix the download survey script not working. 

## Jira Ticket:
https://edlyio.atlassian.net/browse/EDLY-7152?atlOrigin=eyJpIjoiYmJjM2UyMmM0M2ZhNDBjZGJhZDE4ZjdjMjkwMTFhYzEiLCJwIjoiaiJ9