### PR TITLE
EDLY-7080: Fix random password generation during third party auth

### DIFF
--- a/common/djangoapps/util/password_policy_validators.py
+++ b/common/djangoapps/util/password_policy_validators.py
@@ -21,6 +21,8 @@ log = logging.getLogger(__name__)
 # characters. The point of this restriction is to restrict the login page password field to prevent
 # any sort of attacks involving sending massive passwords.
 DEFAULT_MAX_PASSWORD_LENGTH = 5000
+SPECIAL_CHARACTERS = "!@#$%^&*"
+COMMON_SYMBOLS = "$+<=>^`|~"
 
 
 def create_validator_config(name, options={}):
@@ -496,7 +498,7 @@ class SpecialCharactersValidator(object):
         self.min_symbol = min_symbol
 
     def validate(self, password, user=None):
-        if _validate_condition(password, lambda c: c in '!@#$%^&*', self.min_symbol):
+        if _validate_condition(password, lambda c: c in SPECIAL_CHARACTERS, self.min_symbol):
             return
         raise ValidationError(
             ungettext(

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -51,7 +51,7 @@ from openedx.core.djangoapps.user_api.accounts.api import (
 )
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
-from openedx.core.djangoapps.user_authn.utils import generate_password, is_registration_api_v1
+from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1
 from openedx.core.djangoapps.user_authn.views.registration_form import (
     AccountCreationForm,
     RegistrationFormFactory,
@@ -67,6 +67,7 @@ from openedx.features.edly.utils import (
     create_user_unsubscribe_url,
     has_not_unsubscribe_user_email,
     is_config_enabled,
+    generate_password,
     get_edly_sub_org_from_request,
     get_username_and_name_by_email
 )
@@ -184,6 +185,7 @@ def create_account_with_params(request, params):
 
     if is_third_party_auth_enabled and (pipeline.running(request) or third_party_auth_credentials_in_api):
         params["password"] = generate_password()
+        params["confirm_password"] = params["password"]
 
     # in case user is registering via third party (Google, Facebook) and pipeline has expired, show appropriate
     # error message

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -1164,6 +1164,18 @@ class RegistrationFormFactory(object):
                         instructions="",
                         restrictions={}
                     )
+
+                    # Hide the confirm password field
+                    form_desc.override_field_properties(
+                        "confirm_password",
+                        default="",
+                        field_type="hidden",
+                        required=False,
+                        label="",
+                        instructions="",
+                        restrictions={}
+                    )
+
                     # used to identify that request is running third party social auth
                     form_desc.add_field(
                         "social_auth_provider",


### PR DESCRIPTION
Description
This PR solves the issue where randomly generated password fails validation if some custom settings have been added to 
AUTH_PASSWORD_VALIDATORS. The new logic generates a password based on the validators present in AUTH_PASSWORD_VALIDATORS.

Jira:
https://edlyio.atlassian.net/browse/EDLY-7080