### PR TITLE
Feat: Version bump from edly-v8.1.2 to edly-v8.1.3 for lti-xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -266,7 +266,7 @@ git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblo
 -e git+https://github.com/PakistanX/xblock-image-explorer.git@v2.1#egg=xblock-image-explorer==v2.1
 -e git+https://github.com/edly-io/carousel-xblock.git@v1.0.0#egg=edly-carousel-xblock
 -e git+https://github.com/edly-io/zoom-meeting-xblock.git@v-1.0.0#egg=zoom_meeting_xblock==v-1.0.0
--e git+https://github.com/edly-io/xblock-lti-consumer.git@edly-v8.1.2#egg=lti-consumer-xblock
+-e git+https://github.com/edly-io/xblock-lti-consumer.git@edly-v8.1.3#egg=lti-consumer-xblock
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
 


### PR DESCRIPTION
This PR updates the version of the lti-xblock to edly-v8.1.3. 