### PR TITLE
Fix: Course title string in program detail page

### DIFF
--- a/lms/static/js/learner_dashboard/views/course_entitlement_view.js
+++ b/lms/static/js/learner_dashboard/views/course_entitlement_view.js
@@ -90,6 +90,15 @@ class CourseEntitlementView extends Backbone.View {
     });
   }
 
+  escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+  }
+
   handleEnrollChange() {
     /*
     Handles enrolling in a course, unenrolling in a session and changing session.

--- a/lms/templates/learner_dashboard/course_card.underscore
+++ b/lms/templates/learner_dashboard/course_card.underscore
@@ -5,10 +5,10 @@
                 <h5 class="course-title">
                     <% if (course_title_link) { %>
                         <a href="<%- course_title_link %>" class="course-title-link">
-                            <%- title %>
+                            <%- escapeHtml(title) %>
                         </a>
                     <% } else { %>
-                        <%- title %>
+                        <%- escapeHtml(title) %>
                     <% } %>
                 </h5>
                 <div class="course-text">


### PR DESCRIPTION
**Description:** This PR fixes the course title characters not being escaped on program details page.
