### PR TITLE
Fixed course being accessed from studio of another site

### DIFF
--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -28,6 +28,7 @@ from common.djangoapps.student.auth import (
     has_studio_read_access,
     has_studio_write_access
 )
+from openedx.features.edly.utils import is_course_org_same_as_site_org
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, LibraryUserRole
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from xmodule.modulestore import ModuleStoreEnum
@@ -273,6 +274,9 @@ def manage_library_users(request, library_key_string):
         raise Http404  # This is not a library
     user_perms = get_user_permissions(request.user, library_key)
     if not user_perms & STUDIO_VIEW_USERS:
+        raise PermissionDenied()
+    site = request.site
+    if not is_course_org_same_as_site_org(site, library_key, is_studio=True):
         raise PermissionDenied()
     library = modulestore().get_library(library_key)
     if library is None:

--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -19,6 +19,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, LibraryUserRole
 from common.djangoapps.util.json_request import JsonResponse, expect_json
 from xmodule.modulestore.django import modulestore
+from openedx.features.edly.utils import is_course_org_same_as_site_org
 
 __all__ = ['request_course_creator', 'course_team_handler']
 
@@ -77,6 +78,9 @@ def _manage_users(request, course_key):
     # check that logged in user has permissions to this item
     user_perms = get_user_permissions(request.user, course_key)
     if not user_perms & STUDIO_VIEW_USERS:
+        raise PermissionDenied()
+    site = request.site
+    if not is_course_org_same_as_site_org(site, course_key, is_studio=True):
         raise PermissionDenied()
 
     course_module = modulestore().get_course(course_key)

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -11,8 +11,7 @@ from crum import get_current_request
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from opaque_keys.edx.locator import LibraryLocator
-
-from openedx.features.edly.utils import get_edly_sub_org_from_request
+from openedx.features.edly.utils import get_edly_sub_org_from_request, is_course_org_same_as_site_org
 from common.djangoapps.student.roles import (
     CourseBetaTesterRole,
     CourseCreatorRole,
@@ -118,6 +117,10 @@ def has_studio_write_access(user, course_key):
     :param user:
     :param course_key: a CourseKey
     """
+    request = get_current_request()
+    if not is_course_org_same_as_site_org(request.site, course_key, is_studio=True):
+        return False
+
     return bool(STUDIO_EDIT_CONTENT & get_user_permissions(user, course_key))
 
 
@@ -136,6 +139,10 @@ def has_studio_read_access(user, course_key):
     There is currently no such thing as read-only course access in studio, but
     there is read-only access to content libraries.
     """
+    request = get_current_request()
+    if not is_course_org_same_as_site_org(request.site, course_key, is_studio=True):
+        return False
+
     return bool(STUDIO_VIEW_CONTENT & get_user_permissions(user, course_key))
 
 

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -519,12 +519,15 @@ def get_marketing_link(marketing_urls, name):
         return ''
 
 
-def is_course_org_same_as_site_org(site, course_id):
+def is_course_org_same_as_site_org(site, course_id, is_studio=False):
     """
     Check if the course organization matches with the site organization.
     """
     try:
-        edly_sub_org = EdlySubOrganization.objects.get(lms_site=site)
+        if is_studio:
+            edly_sub_org = EdlySubOrganization.objects.get(studio_site=site)
+        else:
+            edly_sub_org = EdlySubOrganization.objects.get(lms_site=site)
     except EdlySubOrganization.DoesNotExist:
         LOGGER.info('No Edly sub organization found for site %s', site)
         return False


### PR DESCRIPTION
This PR fixes the issue of course endpoints of a different organization being accessed from another site for admin. 

JIRA: https://edlyio.atlassian.net/browse/EDLY-7167