### PR TITLE
fix: validation failure when confirm_password is optional

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -259,6 +259,7 @@ class AccountCreationForm(forms.Form):
         confirm_password = self.cleaned_data["confirm_password"]
         if (
                 "password" in self.cleaned_data and
+                "confirm_password" in self.data and
                 self.cleaned_data["password"] != confirm_password
         ):
             raise ValidationError(_("The passwords must match."))


### PR DESCRIPTION
## Description
This PR fixes the issue where even if `confirm_password` field was set as `hidden` the validations would run and cause error in User registration

## Ticket
https://projects.arbisoft.com/project/edly-product/task/7114