### PR TITLE
Fix: resolve issue with chatgpt and ai-coach xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -262,8 +262,8 @@ git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblo
 -e git+https://github.com/edly-io/xblock-poll.git@edly-1.0.0#egg=xblock-poll==edly-1.0.0
 -e git+https://github.com/pmitros/FeedbackXBlock.git#egg=feedback-xblock
 -e git+https://github.com/edly-io/kwl-xblock.git@v1.0.0#egg=kwl-xblock
--e git+https://github.com/edly-io/chatgpt-xblock.git@v1.0.1#egg=chatgpt-xblock==v1.0.1
--e git+https://github.com/edly-io/ai-coach-xblock.git@1.0.6#egg=ai-coach-xblock==1.0.6
+-e git+https://github.com/edly-io/chatgpt-xblock.git@v1.0.2#egg=chatgpt-xblock==v1.0.2
+-e git+https://github.com/edly-io/ai-coach-xblock.git@1.1.0#egg=ai-coach-xblock==1.1.0
 -e git+https://github.com/PakistanX/xblock-image-explorer.git@v2.1#egg=xblock-image-explorer==v2.1
 -e git+https://github.com/edly-io/carousel-xblock.git@v1.0.0#egg=edly-carousel-xblock
 -e git+https://github.com/edly-io/zoom-meeting-xblock.git@v-1.0.0#egg=zoom_meeting_xblock==v-1.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -335,8 +335,8 @@ git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblo
 -e git+ssh://git@github.com/edly-io/xblock-video.git@dev#egg=video_xblock
 -e git+ssh://git@github.com/edly-io/xblock-poll.git@edly-1.0.0#egg=xblock-poll==edly-1.0.0
 -e git+ssh://git@github.com/edly-io/kwl-xblock.git@v1.0.0#egg=kwl-xblock
--e git+ssh://git@github.com/edly-io/chatgpt-xblock.git@v1.0.1#egg=chatgpt-xblock==v1.0.1
--e git+https://github.com/edly-io/ai-coach-xblock.git@1.0.6#egg=ai-coach-xblock==1.0.6
+-e git+https://github.com/edly-io/chatgpt-xblock.git@v1.0.2#egg=chatgpt-xblock==v1.0.2
+-e git+https://github.com/edly-io/ai-coach-xblock.git@1.1.0#egg=ai-coach-xblock==1.1.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
## Description:
This PR fixed the issue related to ChatGPT and Coach AI block. 

For coach AI, the latest version is not backward compatible with the Koa release. So, I created a branch from version 1.0.7 and pulled some commits from upstream to fix the required issue. Additionally, to support the latest code, the version of OpenAI is bumped in it. The [commit here](https://github.com/edly-io/ai-coach-xblock/pull/18/files) making it incompatible with koa. 

https://github.com/edly-io/ai-coach-xblock/compare/1.0.7...Anas/Fix-devstack-issues


For the chatgpt block, the code was not compatible with the bump version of OpenAI. So, we have to update the code to support the logic with openai=1.65.5. Additionally, the syntax issue in the JS file regarding getting elements is resolved. Below is a rebase of ChatGPT xblock with some improvement/bug fixes. 

https://github.com/abconlinecourses/chatgpt-xblock/compare/main...edly-io:chatgpt-xblock:Anas/Fix-chatgpt-xblock?expand=1


## Views: 
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/1fa0c621-c55a-4265-8d7b-5356c4b64aed" />

<br/>
<br/>
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/c747b8a1-194b-405f-91ce-9c3c67b5e94f" />

