### PR TITLE
fix: add authentication to tracking API

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -621,9 +621,7 @@ def course_listing(request):
     split_archived = settings.FEATURES.get(u'ENABLE_SEPARATE_ARCHIVED_COURSES', False)
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
-
-    site_config = configuration_helpers.get_current_site_configuration()
-    tracking_api_url = f"{site_config.get_value('PANEL_NOTIFICATIONS_BASE_URL')}/api/v1/tracking_events/"
+    tracking_api_url = reverse('edly_panel_api:v1:tracking_events')
     frontent_redirect_url = ''
     frontend_url = [url for url in settings.CORS_ORIGIN_WHITELIST if 'apps' in url]   
     if len(frontend_url):

--- a/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
+++ b/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
@@ -27,12 +27,13 @@ export function CourseOrLibraryListing(props) {
     const can_archive = props.can_archive;
 
     const sendTracking = () => {
-        const url = props.tracking_api_url;
+        const url = window.location.origin + props.tracking_api_url;
         const requestData = { event_data: { has_viewed_course: "true" } };
         fetch(url, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
+                'X-CSRFToken': $.cookie('csrftoken')
             },
             body: JSON.stringify(requestData),
         });

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -619,12 +619,13 @@ from openedx.core.djangolib.js_utils import (
     })(window, document, "clarity", "script","${settings.CLARITY_PROJECT_ID}");
 
     function sendTracking(data) {
-        const url = "${tracking_api_url}";
+        const url = window.location.origin + "${tracking_api_url}";
         requestData = { event_data: data }
         fetch(url, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'X-CSRFToken': $.cookie('csrftoken')
             },
             body: JSON.stringify(requestData)
         })


### PR DESCRIPTION
**Description:** 
This PR adds authentication class to `panel-backend` api for sending Mixpanel/hubspot tracking events. We call an api in Studio that adds a signature to the request sent to `panel-backend`

**JIRA:** 
https://projects.arbisoft.com/project/edly-product/us/7112
