### PR TITLE
Fix: Add a dictionary for plan feature for subscription cancellation

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -627,7 +627,7 @@ def course_listing(request):
     frontent_redirect_url = ''
     frontend_url = [url for url in settings.CORS_ORIGIN_WHITELIST if 'apps' in url]   
     if len(frontend_url):
-        frontent_redirect_url = '{}/panel/settings/billing'.format(frontend_url[0])
+        frontent_redirect_url = '{}/panel/billing'.format(frontend_url[0])
     
     try:
         destination_course_id = DESTINATION_COURSE_ID_PATTERN.format(org[0])

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -66,6 +66,7 @@ from openedx.features.edly.constants import (
     STAFF_USERS,
     TRIAL,
     WP_ADMIN_USERS,
+    SUBSCRIPTION_CANCELLED
 )
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 
@@ -4419,6 +4420,16 @@ PLAN_FEATURES = {
         PANEL_ADMINS: 99999999,
     },
     LEGACY: {
+        ADDITIONAL_USER_PRICE: 0,
+        MONTHLY_ACTIVE_USERS: 99999999,
+        NUMBER_OF_REGISTERED_USERS: 99999999,
+        NUMBER_OF_COURSES: 99999999,
+        STAFF_USERS: 99999999,
+        WP_ADMIN_USERS: 99999999,
+        COURSE_AUTHORS: 99999999,
+        PANEL_ADMINS: 99999999,
+    },
+    SUBSCRIPTION_CANCELLED: {
         ADDITIONAL_USER_PRICE: 0,
         MONTHLY_ACTIVE_USERS: 99999999,
         NUMBER_OF_REGISTERED_USERS: 99999999,

--- a/openedx/features/edly/constants.py
+++ b/openedx/features/edly/constants.py
@@ -10,6 +10,7 @@ EDLY_SAAS = 'edly_saas'
 LEGACY = 'legacy'
 TRIAL_EXPIRED = 'trial expired'
 DEACTIVATED = 'deactivated'
+SUBSCRIPTION_CANCELLED = 'subscription_cancelled'
 
 # FEATURE FLAGS
 ADDITIONAL_USER_PRICE = 'additional_user_price'


### PR DESCRIPTION
PR adds a limitation for the cancel subscription user same as the free trial user. 