### PR TITLE
fix: add locking to certificate task to avoid duplication

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -174,7 +174,7 @@ def recalculate_course_and_subsection_grades_for_user(self, **kwargs):  # pylint
     max_retries=2,
     default_retry_delay=RETRY_DELAY_SECONDS
 )
-@locked(expiry_seconds=RECALCULATE_GRADE_DELAY_SECONDS, key='user_id')
+@locked(key='user_id')
 def recalculate_subsection_grade_v3(self, **kwargs):
     """
     Latest version of the recalculate_subsection_grade task.  See docstring


### PR DESCRIPTION
## Description
If a `certificate generation` task is received while another one is in progress then duplicate certificate emails are sent. This PR adds a locking mechanism so duplicate tasks are not created