### PR TITLE
fix: open program certificate in new tab

### DIFF
--- a/lms/templates/learner_dashboard/program_details_sidebar.underscore
+++ b/lms/templates/learner_dashboard/program_details_sidebar.underscore
@@ -1,7 +1,7 @@
 <aside class="aside js-program-progress program-progress">
     <% if (programCertificate) { %>
         <h2 class="progress-heading certificate-heading"><%- StringUtils.interpolate(gettext('Your {program} Certificate'), {program: type}, true) %></h2>
-        <a href="<%- programCertificate.url %>" class="btn-brand btn cta-primary">
+        <a href="<%- programCertificate.url %>" class="btn-brand btn cta-primary" target="_blank" rel="noopener noreferrer">
             Program Certificate
         </a>
     <% } %>


### PR DESCRIPTION
## Description
This PR updates so program certificates are opened in new tab.

## Ticket
https://projects.arbisoft.com/project/edly-product/task/7533