### PR TITLE
feat: Remove ENABLE_FORUM_V2 waffle flag and update tests

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
@@ -60,28 +60,27 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
     Provides test cases to verify that views pass the correct `group_id` to
     the comments service when requesting content in cohorted discussions.
     """
-    def call_view(self, mock_is_forum_v2_enabled, mock_request, commentable_id, user, group_id, pass_group_id=True):
+    def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
         """
         Call the view for the implementing test class, constructing a request
         from the parameters.
         """
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
-    def test_cohorted_topic_student_without_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.student, '', pass_group_id=False)
+    def test_cohorted_topic_student_without_group_id(self, mock_request):
+        self.call_view(mock_request, "cohorted_topic", self.student, '', pass_group_id=False)
         self._assert_comments_service_called_with_group_id(mock_request, self.student_cohort.id)
 
-    def test_cohorted_topic_student_none_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.student, "")
+    def test_cohorted_topic_student_none_group_id(self, mock_request):
+        self.call_view(mock_request, "cohorted_topic", self.student, "")
         self._assert_comments_service_called_with_group_id(mock_request, self.student_cohort.id)
 
-    def test_cohorted_topic_student_with_own_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.student, self.student_cohort.id)
+    def test_cohorted_topic_student_with_own_group_id(self, mock_request):
+        self.call_view(mock_request, "cohorted_topic", self.student, self.student_cohort.id)
         self._assert_comments_service_called_with_group_id(mock_request, self.student_cohort.id)
 
-    def test_cohorted_topic_student_with_other_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_student_with_other_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "cohorted_topic",
             self.student,
@@ -89,9 +88,8 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_with_group_id(mock_request, self.student_cohort.id)
 
-    def test_cohorted_topic_moderator_without_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_moderator_without_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "cohorted_topic",
             self.moderator,
@@ -100,13 +98,12 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_cohorted_topic_moderator_none_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.moderator, "")
+    def test_cohorted_topic_moderator_none_group_id(self, mock_request):
+        self.call_view(mock_request, "cohorted_topic", self.moderator, "")
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_cohorted_topic_moderator_with_own_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_moderator_with_own_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "cohorted_topic",
             self.moderator,
@@ -114,9 +111,8 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_with_group_id(mock_request, self.moderator_cohort.id)
 
-    def test_cohorted_topic_moderator_with_other_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_moderator_with_other_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "cohorted_topic",
             self.moderator,
@@ -124,12 +120,12 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_with_group_id(mock_request, self.student_cohort.id)
 
-    def test_cohorted_topic_moderator_with_invalid_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_moderator_with_invalid_group_id(self, mock_request):
         invalid_id = self.student_cohort.id + self.moderator_cohort.id
-        response = self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
+        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
         assert response.status_code == 500
 
-    def test_cohorted_topic_enrollment_track_invalid_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_cohorted_topic_enrollment_track_invalid_group_id(self, mock_request):
         CourseModeFactory.create(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
         CourseModeFactory.create(course_id=self.course.id, mode_slug=CourseMode.VERIFIED)
         discussion_settings = CourseDiscussionSettings.get(self.course.id)
@@ -140,7 +136,7 @@ class CohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         })
 
         invalid_id = -1000
-        response = self.call_view(mock_is_forum_v2_enabled, mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
+        response = self.call_view(mock_request, "cohorted_topic", self.moderator, invalid_id)  # lint-amnesty, pylint: disable=assignment-from-no-return
         assert response.status_code == 500
 
 
@@ -149,16 +145,15 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
     Provides test cases to verify that views pass the correct `group_id` to
     the comments service when requesting content in non-cohorted discussions.
     """
-    def call_view(self, mock_is_forum_v2_enabled, mock_request, commentable_id, user, group_id, pass_group_id=True):
+    def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
         """
         Call the view for the implementing test class, constructing a request
         from the parameters.
         """
         pass  # lint-amnesty, pylint: disable=unnecessary-pass
 
-    def test_non_cohorted_topic_student_without_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_student_without_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.student,
@@ -167,13 +162,12 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_student_none_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "non_cohorted_topic", self.student, '')
+    def test_non_cohorted_topic_student_none_group_id(self, mock_request):
+        self.call_view(mock_request, "non_cohorted_topic", self.student, '')
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_student_with_own_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_student_with_own_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.student,
@@ -181,9 +175,8 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_student_with_other_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_student_with_other_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.student,
@@ -191,9 +184,8 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_moderator_without_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_moderator_without_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.moderator,
@@ -202,13 +194,12 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_moderator_none_group_id(self, mock_is_forum_v2_enabled, mock_request):
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "non_cohorted_topic", self.moderator, '')
+    def test_non_cohorted_topic_moderator_none_group_id(self, mock_request):
+        self.call_view(mock_request, "non_cohorted_topic", self.moderator, '')
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_moderator_with_own_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_moderator_with_own_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.moderator,
@@ -216,9 +207,8 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_moderator_with_other_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_moderator_with_other_group_id(self, mock_request):
         self.call_view(
-            mock_is_forum_v2_enabled,
             mock_request,
             "non_cohorted_topic",
             self.moderator,
@@ -226,19 +216,19 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         )
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_non_cohorted_topic_moderator_with_invalid_group_id(self, mock_is_forum_v2_enabled, mock_request):
+    def test_non_cohorted_topic_moderator_with_invalid_group_id(self, mock_request):
         invalid_id = self.student_cohort.id + self.moderator_cohort.id
-        self.call_view(mock_is_forum_v2_enabled, mock_request, "non_cohorted_topic", self.moderator, invalid_id)
+        self.call_view(mock_request, "non_cohorted_topic", self.moderator, invalid_id)
         self._assert_comments_service_called_without_group_id(mock_request)
 
-    def test_team_discussion_id_not_cohorted(self, mock_is_forum_v2_enabled, mock_request):
+    def test_team_discussion_id_not_cohorted(self, mock_request):
         team = CourseTeamFactory(
             course_id=self.course.id,
             topic_id='topic-id'
         )
 
         team.add_user(self.student)
-        self.call_view(mock_is_forum_v2_enabled, mock_request, team.discussion_topic_id, self.student, '')
+        self.call_view(mock_request, team.discussion_topic_id, self.student, '')
 
         self._assert_comments_service_called_without_group_id(mock_request)
 

--- a/lms/djangoapps/discussion/django_comment_client/tests/mixins.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/mixins.py
@@ -17,13 +17,6 @@ class MockForumApiMixin:
         """
         cls.mock_forum_api = mock.Mock()
 
-        # TODO: Remove this after moving all APIs
-        cls.flag_v2_patcher = mock.patch(
-            "openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled"
-        )
-        cls.mock_enable_forum_v2 = cls.flag_v2_patcher.start()
-        cls.mock_enable_forum_v2.return_value = True
-
         patch_targets = [
             "openedx.core.djangoapps.django_comment_common.comment_client.thread.forum_api",
             "openedx.core.djangoapps.django_comment_common.comment_client.comment.forum_api",
@@ -41,8 +34,6 @@ class MockForumApiMixin:
     @classmethod
     def disposeForumMocks(cls):
         """Stop patches after tests complete."""
-        cls.flag_v2_patcher.stop()
-
         for patcher in cls.forum_api_patchers:
             patcher.stop()
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
@@ -58,12 +58,6 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, ForumMockUtilsMixi
         self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
         patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=True
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.models.forum_api.get_course_id_by_comment"
         )
         self.mock_get_course_id_by_comment = patcher.start()
@@ -420,12 +414,6 @@ class ThreadSerializerDeserializationTest(
         httpretty.enable()
         self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=True
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
         self.user = UserFactory.create()
         self.register_get_user_response(self.user)
         self.request = RequestFactory().get("/dummy")
@@ -572,12 +560,6 @@ class SerializerTestMixin(ForumsEnableMixin, UrlResetMixin, ForumMockUtilsMixin)
         httpretty.enable()
         self.addCleanup(httpretty.reset)
         self.addCleanup(httpretty.disable)
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=True
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
         patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.models.forum_api.get_course_id_by_comment"

--- a/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_tasks_v2.py
@@ -60,46 +60,19 @@ class TestSendResponseNotifications(DiscussionAPIViewTestMixin, ModuleStoreTestC
 
         self.course = CourseFactory.create()
 
-        # Patch 1
-        patcher1 = mock.patch(
-            'openedx.core.djangoapps.django_comment_common.comment_client.thread.is_forum_v2_enabled_for_thread',
-            autospec=True
-        )
-        mock_forum_v2 = patcher1.start()
-        mock_forum_v2.return_value = (True, str(self.course.id))
-        self.addCleanup(patcher1.stop)
-
-        # Patch 2
-        patcher2 = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher2.start()
-        self.addCleanup(patcher2.stop)
-
-        # Patch 3
-        patcher3 = mock.patch(
+        patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.thread.forum_api.get_course_id_by_thread",
             return_value=self.course.id
         )
-        self.mock_get_course_id_by_thread = patcher3.start()
-        self.addCleanup(patcher3.stop)
+        self.mock_get_course_id_by_thread = patcher.start()
+        self.addCleanup(patcher.stop)
 
-        # Patch 4
-        patcher4 = mock.patch(
+        patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.models.forum_api.get_course_id_by_comment",
             return_value=self.course.id
         )
-        self.mock_get_course_id_by_comment = patcher4.start()
-        self.addCleanup(patcher4.stop)
-
-        # Patch 5
-        patcher5 = mock.patch(
-            "openedx.core.djangoapps.django_comment_common.comment_client.models.is_forum_v2_enabled_for_comment",
-            return_value=(True, str(self.course.id))
-        )
-        self.mock_is_forum_v2_enabled_for_comment = patcher5.start()
-        self.addCleanup(patcher5.stop)
+        self.mock_get_course_id_by_comment = patcher.start()
+        self.addCleanup(patcher.stop)
 
         self.user_1 = UserFactory.create()
         CourseEnrollment.enroll(self.user_1, self.course.id)
@@ -410,20 +383,6 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
         super().setUp()
         httpretty.reset()
         httpretty.enable()
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch(
-            'openedx.core.djangoapps.django_comment_common.comment_client.thread.is_forum_v2_enabled_for_thread',
-            autospec=True
-        )
-        mock_forum_v2 = patcher.start()
-        mock_forum_v2.return_value = (True, str(self.course.id))
-        self.addCleanup(patcher.stop)
 
         self.course = CourseFactory.create()
         patcher = mock.patch(
@@ -437,13 +396,6 @@ class TestSendCommentNotification(DiscussionAPIViewTestMixin, ModuleStoreTestCas
             return_value=self.course.id
         )
         self.mock_get_course_id_by_comment = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        patcher = mock.patch(
-            "openedx.core.djangoapps.django_comment_common.comment_client.models.is_forum_v2_enabled_for_comment",
-            return_value=(True, str(self.course.id))
-        )
-        self.mock_is_forum_v2_enabled_for_comment = patcher.start()
         self.addCleanup(patcher.stop)
 
         self.user_1 = UserFactory.create()

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -2155,12 +2155,6 @@ class CourseActivityStatsTest(ForumsEnableMixin, UrlResetMixin, ForumMockUtilsMi
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self) -> None:
         super().setUp()
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
         self.course = CourseFactory.create()
         self.course_key = str(self.course.id)
         seed_permissions_roles(self.course.id)
@@ -2319,12 +2313,6 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.superuser_client = APIClient()
         self.retired_username = get_retired_username_by_username(self.user.username)
         self.url = reverse("retire_discussion_user")
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def assert_response_correct(self, response, expected_status, expected_content):
         """
@@ -2390,12 +2378,6 @@ class UploadFileViewTest(ForumsEnableMixin, ForumMockUtilsMixin, UrlResetMixin, 
         self.user = UserFactory.create(password=self.TEST_PASSWORD)
         self.course = CourseFactory.create(org='a', course='b', run='c', start=datetime.now(UTC))
         self.url = reverse("upload_file", kwargs={"course_id": str(self.course.id)})
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     @classmethod
     def setUpClass(cls):
@@ -2543,12 +2525,6 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     def setUp(self):
         super().setUp()
         self.url = reverse("discussion_course", kwargs={"course_id": str(self.course.id)})
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def test_404(self):
         response = self.client.get(
@@ -2606,12 +2582,6 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.worker_client = APIClient()
         self.new_username = "test_username_replacement"
         self.url = reverse("replace_discussion_username")
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def assert_response_correct(self, response, expected_status, expected_content):
         """
@@ -2714,12 +2684,6 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, CommentsServiceMockMixin,
             "courseware-3": {"discussion": 7, "question": 2},
         }
         self.register_get_course_commentable_counts_response(self.course.id, self.thread_counts_map)
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def create_course(self, blocks_count, module_store, topics):
         """
@@ -2975,12 +2939,6 @@ class CourseTopicsViewV3Test(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
         self.url = reverse("course_topics_v3", kwargs={"course_id": str(self.course.id)})
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def test_basic(self):
         response = self.client.get(self.url)
@@ -3025,12 +2983,6 @@ class CourseDiscussionSettingsAPIViewTest(APITestCase, UrlResetMixin, ModuleStor
         self.path = reverse('discussion_course_settings', kwargs={'course_id': str(self.course.id)})
         self.password = self.TEST_PASSWORD
         self.user = UserFactory(username='staff', password=self.password, is_staff=True)
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
 
     def _get_oauth_headers(self, user):
         """Return the OAuth headers for testing OAuth authentication"""
@@ -3320,12 +3272,6 @@ class CourseDiscussionRolesAPIViewTest(APITestCase, UrlResetMixin, ModuleStoreTe
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
         self.course = CourseFactory.create(
             org="x",
             course="y",

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -93,12 +93,6 @@ class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):  # lint-amnest
         config.enabled = True
         config.save()
         patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-        patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.thread.forum_api.get_course_id_by_thread"
         )
         self.mock_get_course_id_by_thread = patcher.start()
@@ -337,12 +331,6 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super().setUp()
-        patcher = mock.patch(
-            'openedx.core.djangoapps.discussions.config.waffle.ENABLE_FORUM_V2.is_enabled',
-            return_value=False
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
         patcher = mock.patch(
             "openedx.core.djangoapps.django_comment_common.comment_client.models.forum_api.get_course_id_by_comment"
         )

--- a/openedx/core/djangoapps/discussions/config/waffle.py
+++ b/openedx/core/djangoapps/discussions/config/waffle.py
@@ -2,8 +2,6 @@
 This module contains various configuration settings via
 waffle switches for the discussions app.
 """
-from django.conf import settings
-
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = "discussions"
@@ -45,31 +43,3 @@ ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND = CourseWaffleFlag(
 ENABLE_NEW_STRUCTURE_DISCUSSIONS = CourseWaffleFlag(
     f"{WAFFLE_FLAG_NAMESPACE}.enable_new_structure_discussions", __name__
 )
-
-# .. toggle_name: discussions.enable_forum_v2
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Waffle flag to use the forum v2 instead of v1(cs_comment_service)
-# .. toggle_use_cases: temporary, open_edx
-# .. toggle_creation_date: 2024-9-26
-# .. toggle_target_removal_date: 2025-12-05
-ENABLE_FORUM_V2 = CourseWaffleFlag(f"{WAFFLE_FLAG_NAMESPACE}.enable_forum_v2", __name__)
-
-
-def is_forum_v2_enabled(course_key):
-    """
-    Returns whether forum V2 is enabled on the course. This is a 2-step check:
-
-    1. Check value of settings.DISABLE_FORUM_V2: if it exists and is true, this setting overrides any course flag.
-    2. Else, check the value of the corresponding course waffle flag.
-    """
-    if is_forum_v2_disabled_globally():
-        return False
-    return ENABLE_FORUM_V2.is_enabled(course_key)
-
-
-def is_forum_v2_disabled_globally() -> bool:
-    """
-    Return True if DISABLE_FORUM_V2 is defined and true-ish.
-    """
-    return getattr(settings, "DISABLE_FORUM_V2", False)

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -2,11 +2,9 @@
 
 
 import logging
-import typing as t
 
 from .utils import CommentClientRequestError, extract, perform_request, get_course_key
 from forum import api as forum_api
-from openedx.core.djangoapps.discussions.config.waffle import is_forum_v2_enabled, is_forum_v2_disabled_globally
 
 log = logging.getLogger(__name__)
 
@@ -324,22 +322,3 @@ class Model:
 
         response = forum_api.create_thread(**params)
         return response
-
-
-def is_forum_v2_enabled_for_comment(comment_id: str) -> tuple[bool, t.Optional[str]]:
-    """
-    Figure out whether we use forum v2 for a given comment.
-
-    See is_forum_v2_enabled_for_thread.
-
-    Return:
-
-        enabled (bool)
-        course_id (str or None)
-    """
-    if is_forum_v2_disabled_globally():
-        return False, None
-
-    course_id = forum_api.get_course_id_by_comment(comment_id)
-    course_key = get_course_key(course_id)
-    return is_forum_v2_enabled(course_key), course_id

--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -2,13 +2,11 @@
 
 
 import logging
-import typing as t
 
 from eventtracking import tracker
 
 from . import models, settings, utils
 from forum import api as forum_api
-from openedx.core.djangoapps.discussions.config.waffle import is_forum_v2_enabled, is_forum_v2_disabled_globally
 
 log = logging.getLogger(__name__)
 
@@ -161,7 +159,7 @@ class Thread(models.Model):
         request_params = _clean_forum_params(request_params)
         course_id = kwargs.get("course_id")
         if not course_id:
-            _, course_id = is_forum_v2_enabled_for_thread(self.id)
+            course_id = forum_api.get_course_id_by_thread(self.id)
         if user_id := request_params.get('user_id'):
             request_params['user_id'] = str(user_id)
         response = forum_api.get_thread(
@@ -233,28 +231,3 @@ def _clean_forum_params(params):
             else:
                 result[k] = v
     return result
-
-
-def is_forum_v2_enabled_for_thread(thread_id: str) -> tuple[bool, t.Optional[str]]:
-    """
-    Figure out whether we use forum v2 for a given thread.
-
-    This is a complex affair... First, we check the value of the DISABLE_FORUM_V2
-    setting, which overrides everything. If this setting does not exist, then we need to
-    find the course ID that corresponds to the thread ID. Then, we return the value of
-    the course waffle flag for this course ID.
-
-    Note that to fetch the course ID associated to a thread ID, we need to connect both
-    to mongodb and mysql. As a consequence, when forum v2 needs adequate connection
-    strings for both backends.
-
-    Return:
-
-        enabled (bool)
-        course_id (str or None)
-    """
-    if is_forum_v2_disabled_globally():
-        return False, None
-    course_id = forum_api.get_course_id_by_thread(thread_id)
-    course_key = utils.get_course_key(course_id)
-    return is_forum_v2_enabled(course_key), course_id


### PR DESCRIPTION
## Description

This PR removes `ENABLE_FORUM_V2` waffle flag and its corresponding util functions as we have deprecated forum v1 compatibility for all discussion app views. This PR also fixes the tests that were failing as a consequence of these changes.
