### PR TITLE
chore: add PersistantCourseGrades to django admin

### DIFF
--- a/lms/djangoapps/grades/admin.py
+++ b/lms/djangoapps/grades/admin.py
@@ -12,6 +12,7 @@ from lms.djangoapps.grades.config.models import (
     CoursePersistentGradesFlag,
     PersistentGradesEnabledFlag
 )
+from lms.djangoapps.grades.models import PersistentCourseGrade
 
 
 class CoursePersistentGradesAdmin(KeyedConfigurationModelAdmin):
@@ -31,3 +32,4 @@ class CoursePersistentGradesAdmin(KeyedConfigurationModelAdmin):
 admin.site.register(CoursePersistentGradesFlag, CoursePersistentGradesAdmin)
 admin.site.register(PersistentGradesEnabledFlag, ConfigurationModelAdmin)
 admin.site.register(ComputeGradesSetting, ConfigurationModelAdmin)
+admin.site.register(PersistentCourseGrade)


### PR DESCRIPTION
## Description
This table contains very important learner information. Having this in django admin will make debugging much easier. It would also reduce latency issues as we won'y have to request data from devops.