### PR TITLE
Fix: remove read from update_thread params

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -1145,7 +1145,6 @@ class UpdateThreadTest(
             "anonymous_to_peers": False,
             "closed": False,
             "pinned": False,
-            "read": False,
             "editing_user_id": str(self.user.id),
         }
         self.check_mock_called_with("update_thread", -1, **params)

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -271,7 +271,6 @@ class ThreadViewSetPartialUpdateTest(
             "anonymous_to_peers": False,
             "closed": False,
             "pinned": False,
-            "read": True,
             "editing_user_id": str(self.user.id),
         }
         self.check_mock_called_with("update_thread", -1, **params)

--- a/openedx/core/djangoapps/django_comment_common/comment_client/models.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/models.py
@@ -265,7 +265,6 @@ class Model:
             "close_reason_code": request_params.get("close_reason_code"),
             "closing_user_id": request_params.get("closing_user_id"),
             "endorsed": request_params.get("endorsed"),
-            "read": request_params.get("read"),
         }
         request_data = {k: v for k, v in request_data.items() if v is not None}
         response = forum_api.update_thread(**request_data)


### PR DESCRIPTION
### Description

- Removed read from update_thread params.
- Updated test cases accordingly.