### PR TITLE
Remove noreferrer from the “Open Certificate” link

### DIFF
--- a/lms/templates/learner_dashboard/certificate_list.underscore
+++ b/lms/templates/learner_dashboard/certificate_list.underscore
@@ -5,8 +5,8 @@
     <ul class="certificate-list">
       <% _.each(certificateList, function(certificate){ %>
         <li class="certificate">
-            <a class="image-link" href="<%- certificate.url %>" aria-hidden="true" tabindex="-1"><img src="/static/images/programs/certificate-icon.svg" class="sample-cert" alt=""></a>
-            <a class="certificate-link" href="<%- certificate.url %>"><%- certificate.title %></a>
+            <a class="image-link" target="_blank" rel="noopener" href="<%- certificate.url %>" aria-hidden="true" tabindex="-1"><img src="/static/images/programs/certificate-icon.svg" class="sample-cert" alt=""></a>
+            <a class="certificate-link" target="_blank" rel="noopener" href="<%- certificate.url %>"><%- certificate.title %></a>
         </li>
       <% }); %>
     </ul>

--- a/lms/templates/learner_dashboard/program_details_sidebar.underscore
+++ b/lms/templates/learner_dashboard/program_details_sidebar.underscore
@@ -1,7 +1,7 @@
 <aside class="aside js-program-progress program-progress">
     <% if (programCertificate) { %>
         <h2 class="progress-heading certificate-heading"><%- StringUtils.interpolate(gettext('Your {program} Certificate'), {program: type}, true) %></h2>
-        <a href="<%- programCertificate.url %>" class="btn-brand btn cta-primary" target="_blank" rel="noopener noreferrer">
+        <a href="<%- programCertificate.url %>" class="btn-brand btn cta-primary" target="_blank" rel="noopener">
             Program Certificate
         </a>
     <% } %>


### PR DESCRIPTION
Description:
This PR removes `noreferrer` from the rel attribute of `Open certificate` anchor tag. The certificate was not being opened due to `noreferrer`. This may be because credentials service requires Referer header for CSRF validation or origin verification,