### PR TITLE
fix: added Required Asterisk sign in the labels

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/extensions.html
+++ b/lms/templates/instructor/instructor_dashboard_2/extensions.html
@@ -13,11 +13,11 @@ from django.utils.translation import gettext as _
   </p>
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
-        "here:").format(platform_name=settings.PLATFORM_NAME)}
+        "here*:").format(platform_name=settings.PLATFORM_NAME)}
     <input type="text" name="student" placeholder="${_("Student Email or Username")}">
   </p>
   <p>
-    ${_("Choose the graded subsection:")}
+    ${_("Choose the graded subsection*:")}
     <select name="url">
       <option value="">Choose one</option>
       %for title, url in section_data['units_with_due_dates']:
@@ -28,7 +28,7 @@ from django.utils.translation import gettext as _
   <% format_string="MM/DD/YYYY HH:MM" %>
   <p>
     ## Translators: "format_string" is the string MM/DD/YYYY HH:MM, as that is the format the system requires.
-    ${_("Specify the extension due date and time (in UTC; please specify {format_string}).").format(format_string=format_string)}</p>
+    ${_("Specify the extension due date and time (in UTC; please specify {format_string}).").format(format_string=format_string)}*</p>
   <p><input type="text" name="due_datetime" 
            placeholder="${format_string}"/> <input type="text" name="reason" placeholder="${_('Reason for extension')}" size=40 />
   </p>
@@ -52,7 +52,7 @@ from django.utils.translation import gettext as _
         "students who have extensions for the given subsection.")}
   </p>
   <p>
-    ${_("Choose the graded subsection:")}
+    ${_("Choose the graded subsection*:")}
     <select name="url">
       <option value="">Choose one</option>
       %for title, url in section_data['units_with_due_dates']:
@@ -68,7 +68,7 @@ from django.utils.translation import gettext as _
   </p>
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
-        "here:").format(platform_name=settings.PLATFORM_NAME)}
+        "here*:").format(platform_name=settings.PLATFORM_NAME)}
     <input type="text" name="student" placeholder="${_("Student Email or Username")}">
     <input type="button" name="show-student-extensions" 
            value="${_("List date extensions for student")}"
@@ -91,11 +91,11 @@ from django.utils.translation import gettext as _
   </p>
   <p>
     ${_("Specify the {platform_name} email address or username of a student "
-        "here:").format(platform_name=settings.PLATFORM_NAME)}
+        "here*:").format(platform_name=settings.PLATFORM_NAME)}
     <input type="text" name="student" placeholder="${_("Student Email or Username")}">
   </p>
   <p>
-    ${_("Choose the graded subsection:")}
+    ${_("Choose the graded subsection*:")}
     <select name="url">
       <option value="">Choose one</option>
       %for title, url in section_data['units_with_due_dates']:


### PR DESCRIPTION
### Description

On **Discussion** page, while adding the post, Compulsory fields are missing the required alert sign (e.g. Asterisk). So, I've added Asterisk sign on post title and content area to prevent user from posting content without it. This will prevent the error message and save user time.

**Steps to Reproduce:**
Open [Sandbox URL](https://sandbox.openedx.edly.io/courses/course-v1:OpenedX+DemoX+DemoCourse/instructor#view-extensions)
1. Post the form without adding any data to the email or dropdown fields
2. Observe both fields are compulsory

Related to https://github.com/overhangio/tutor-indigo/issues/146

### How Has This Been Tested?
I set up Tutor locally with the Indigo Plugin enabled (which is enabled by default). I followed the above steps to reproduce the issue, inspected the HTML on the frontend, and identified where the adjustment was needed.

#### Sandbox (optional):
[Sandbox Link](https://sandbox.openedx.edly.io/courses/course-v1:OpenedX+DemoX+DemoCourse/instructor#view-extensions)

**Following Taiga tickets has been addressed in this PR(Access required):**
1. https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/41

## Screenshots
**Before**
![image](https://github.com/user-attachments/assets/c655e10d-76b9-4a53-bf3b-b673364b2ce3)

#### Merge Checklist

* [x] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [x] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.