### PR TITLE
Fix: restrict prerequisite course fetching to current site course org.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1231,7 +1231,9 @@ def settings_handler(request, course_key_string):
                 'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
             }
             if is_prerequisite_courses_enabled():
-                courses, in_process_course_actions = get_courses_accessible_to_user(request)
+                courses, in_process_course_actions = get_courses_accessible_to_user(
+                    request, course_module.location.org
+                )
                 # exclude current course from the list of available courses
                 courses = (course for course in courses if course.id != course_key)
                 if courses:


### PR DESCRIPTION
## Description:
The PR addresses the slow schedule and details page issue. On the schedule and details page, the prerequisite section was fetching all the courses and checking the permission for the current user on them. 

The PR filters the course fetch based on the course organization.

## Tiaga Ticket:
https://projects.arbisoft.com/project/edly-product/task/7600