### PR TITLE
feat: remove course_id parameter from forum functions

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests_v2.py
@@ -710,7 +710,6 @@ class ViewsTestCase(
         params = {
             "comment_id": comment_id,
             "body": updated_body,
-            "course_id": str(self.course_id),
         }
         self.check_mock_called_with("update_comment", -1, **params)
 
@@ -767,7 +766,6 @@ class ViewsTestCase(
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -776,7 +774,6 @@ class ViewsTestCase(
             thread_id="518d4237b023791dca00000d",
             action="flag",
             user_id=ANY,
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -789,7 +786,6 @@ class ViewsTestCase(
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            course_id=str(self.course_id),
         )
 
         assert response.status_code == 200
@@ -834,7 +830,6 @@ class ViewsTestCase(
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -844,7 +839,6 @@ class ViewsTestCase(
             action="unflag",
             user_id=ANY,
             update_all=False,
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -857,7 +851,6 @@ class ViewsTestCase(
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            course_id=str(self.course_id),
         )
 
         assert response.status_code == 200
@@ -898,7 +891,6 @@ class ViewsTestCase(
             "get_parent_comment",
             0,
             comment_id="518d4237b023791dca00000d",
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -907,14 +899,12 @@ class ViewsTestCase(
             comment_id="518d4237b023791dca00000d",
             action="flag",
             user_id=ANY,
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
             "get_parent_comment",
             1,
             comment_id="518d4237b023791dca00000d",
-            course_id=str(self.course_id),
         )
 
         assert response.status_code == 200
@@ -955,7 +945,6 @@ class ViewsTestCase(
             "get_parent_comment",
             0,
             comment_id="518d4237b023791dca00000d",
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
@@ -965,14 +954,12 @@ class ViewsTestCase(
             action="unflag",
             update_all=False,
             user_id=ANY,
-            course_id=str(self.course_id),
         )
 
         self.check_mock_called_with(
             "get_parent_comment",
             1,
             comment_id="518d4237b023791dca00000d",
-            course_id=str(self.course_id),
         )
 
         assert response.status_code == 200

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -584,7 +584,7 @@ def create_thread(request, course_id, commentable_id):
 
     if follow:
         cc_user = cc.User.from_django_user(user)
-        cc_user.follow(thread, course_id)
+        cc_user.follow(thread)
         thread_followed.send(sender=None, user=user, post=thread)
 
     data = thread.to_dict()
@@ -715,7 +715,7 @@ def delete_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     course = get_course_with_access(request.user, 'load', course_key)
     thread = cc.Thread.find(thread_id)
-    thread.delete(course_id=course_id)
+    thread.delete()
     thread_deleted.send(sender=None, user=request.user, post=thread)
 
     track_thread_deleted_event(request, course, thread)
@@ -736,7 +736,7 @@ def update_comment(request, course_id, comment_id):
     if 'body' not in request.POST or not request.POST['body'].strip():
         return JsonError(_("Body can't be empty"))
     comment.body = sanitize_body(request.POST["body"])
-    comment.save(params={"course_id": course_id})
+    comment.save()
 
     comment_edited.send(sender=None, user=request.user, post=comment)
 
@@ -762,7 +762,7 @@ def endorse_comment(request, course_id, comment_id):
     endorsed = request.POST.get('endorsed', 'false').lower() == 'true'
     comment.endorsed = endorsed
     comment.endorsement_user_id = user.id
-    comment.save(params={"course_id": course_id})
+    comment.save()
     comment_endorsed.send(sender=None, user=user, post=comment)
     track_forum_response_mark_event(request, course, comment, endorsed)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -781,7 +781,7 @@ def openclose_thread(request, course_id, thread_id):
     thread = cc.Thread.find(thread_id)
     close_thread = request.POST.get('closed', 'false').lower() == 'true'
     thread.closed = close_thread
-    thread.save(params={"course_id": course_id})
+    thread.save()
 
     track_thread_lock_unlock_event(request, course, thread, None, close_thread)
     return JsonResponse({
@@ -814,7 +814,7 @@ def delete_comment(request, course_id, comment_id):
     course_key = CourseKey.from_string(course_id)
     course = get_course_with_access(request.user, 'load', course_key)
     comment = cc.Comment.find(comment_id)
-    comment.delete(course_id=course_id)
+    comment.delete()
     comment_deleted.send(sender=None, user=request.user, post=comment)
     track_comment_deleted_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -828,12 +828,12 @@ def _vote_or_unvote(request, course_id, obj, value='up', undo_vote=False):
     course = get_course_with_access(request.user, 'load', course_key)
     user = cc.User.from_django_user(request.user)
     if undo_vote:
-        user.unvote(obj, course_id)
+        user.unvote(obj)
         # TODO(smarnach): Determine the value of the vote that is undone.  Currently, you can
         # only cast upvotes in the user interface, so it is assumed that the vote value is 'up'.
         # (People could theoretically downvote by handcrafting AJAX requests.)
     else:
-        user.vote(obj, value, course_id)
+        user.vote(obj, value)
     thread_voted.send(sender=None, user=request.user, post=obj)
     track_voted_event(request, course, obj, value, undo_vote)
     return JsonResponse(prepare_content(obj.to_dict(), course_key))
@@ -899,7 +899,7 @@ def flag_abuse_for_thread(request, course_id, thread_id):
     user = cc.User.from_django_user(request.user)
     course = get_course_by_id(course_key)
     thread = cc.Thread.find(thread_id)
-    thread.flagAbuse(user, thread, course_id)
+    thread.flagAbuse(user, thread)
     track_discussion_reported_event(request, course, thread)
     thread_flagged.send(sender='flag_abuse_for_thread', user=request.user, post=thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
@@ -921,7 +921,7 @@ def un_flag_abuse_for_thread(request, course_id, thread_id):
         has_permission(request.user, 'openclose_thread', course_key) or
         has_access(request.user, 'staff', course)
     )
-    thread.unFlagAbuse(user, thread, remove_all, course_id)
+    thread.unFlagAbuse(user, thread, remove_all)
     track_discussion_unreported_event(request, course, thread)
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -938,7 +938,7 @@ def flag_abuse_for_comment(request, course_id, comment_id):
     user = cc.User.from_django_user(request.user)
     course = get_course_by_id(course_key)
     comment = cc.Comment.find(comment_id)
-    comment.flagAbuse(user, comment, course_id)
+    comment.flagAbuse(user, comment)
     track_discussion_reported_event(request, course, comment)
     comment_flagged.send(sender='flag_abuse_for_comment', user=request.user, post=comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
@@ -960,7 +960,7 @@ def un_flag_abuse_for_comment(request, course_id, comment_id):
         has_access(request.user, 'staff', course)
     )
     comment = cc.Comment.find(comment_id)
-    comment.unFlagAbuse(user, comment, remove_all, course_id)
+    comment.unFlagAbuse(user, comment, remove_all)
     track_discussion_unreported_event(request, course, comment)
     return JsonResponse(prepare_content(comment.to_dict(), course_key))
 
@@ -976,7 +976,7 @@ def pin_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    thread.pin(user, thread_id, course_id)
+    thread.pin(user, thread_id)
 
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -992,7 +992,7 @@ def un_pin_thread(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    thread.un_pin(user, thread_id, course_id)
+    thread.un_pin(user, thread_id)
 
     return JsonResponse(prepare_content(thread.to_dict(), course_key))
 
@@ -1005,7 +1005,7 @@ def follow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: disab
     course_key = CourseKey.from_string(course_id)
     course = get_course_by_id(course_key)
     thread = cc.Thread.find(thread_id)
-    user.follow(thread, course_id=course_id)
+    user.follow(thread)
     thread_followed.send(sender=None, user=request.user, post=thread)
     track_thread_followed_event(request, course, thread, True)
     return JsonResponse({})
@@ -1021,7 +1021,7 @@ def follow_commentable(request, course_id, commentable_id):  # lint-amnesty, pyl
     """
     user = cc.User.from_django_user(request.user)
     commentable = cc.Commentable.find(commentable_id)
-    user.follow(commentable, course_id=course_id)
+    user.follow(commentable)
     return JsonResponse({})
 
 
@@ -1037,7 +1037,7 @@ def unfollow_thread(request, course_id, thread_id):  # lint-amnesty, pylint: dis
     course = get_course_by_id(course_key)
     user = cc.User.from_django_user(request.user)
     thread = cc.Thread.find(thread_id)
-    user.unfollow(thread, course_id=course_id)
+    user.unfollow(thread)
     thread_unfollowed.send(sender=None, user=request.user, post=thread)
     track_thread_followed_event(request, course, thread, False)
     return JsonResponse({})
@@ -1053,7 +1053,7 @@ def unfollow_commentable(request, course_id, commentable_id):  # lint-amnesty, p
     """
     user = cc.User.from_django_user(request.user)
     commentable = cc.Commentable.find(commentable_id)
-    user.unfollow(commentable, course_id=course_id)
+    user.unfollow(commentable)
     return JsonResponse({})
 
 

--- a/lms/djangoapps/discussion/rest_api/discussions_notifications.py
+++ b/lms/djangoapps/discussion/rest_api/discussions_notifications.py
@@ -208,7 +208,7 @@ class DiscussionNotificationSender:
 
         while has_more_subscribers:
 
-            subscribers = Subscription.fetch(self.thread.id, self.course.id, query_params={'page': page})
+            subscribers = Subscription.fetch(self.thread.id, query_params={'page': page})
             if page <= subscribers.num_pages:
                 for subscriber in subscribers.collection:
                     # Check if the subscriber is not the thread creator or response creator

--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -68,7 +68,7 @@ def get_context(course, request, thread=None):
     moderator_user_ids = get_moderator_users_list(course.id)
     ta_user_ids = get_course_ta_users_list(course.id)
     requester = request.user
-    cc_requester = CommentClientUser.from_django_user(requester).retrieve(course_id=course.id)
+    cc_requester = CommentClientUser.from_django_user(requester).retrieve()
     cc_requester["course_id"] = course.id
     course_discussion_settings = CourseDiscussionSettings.get(course.id)
     is_global_staff = GlobalStaff().has_user(requester)

--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -564,7 +564,6 @@ class CreateThreadTest(
             "thread_id": "test_id",
             "action": "flag",
             "user_id": "1",
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("update_thread_flag", -1, **params)
 
@@ -581,7 +580,6 @@ class CreateThreadTest(
 
         params = {
             "user_id": str(self.user.id),
-            "course_id": str(self.course.id),
             "source_id": "test_id",
         }
         self.check_mock_called_with("create_subscription", 0, **params)
@@ -928,7 +926,6 @@ class CreateCommentTest(
             "comment_id": "test_comment",
             "action": "flag",
             "user_id": "1",
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("update_comment_flag", -1, **params)
 
@@ -1135,7 +1132,6 @@ class UpdateThreadTest(
         )
         params = {
             "thread_id": "test_thread",
-            "course_id": str(self.course.id),
             "commentable_id": "original_topic",
             "thread_type": "discussion",
             "title": "Original Title",
@@ -1184,7 +1180,6 @@ class UpdateThreadTest(
                 "thread_id": "test_thread",
                 "action": "flag" if new_flagged else "unflag",
                 "user_id": "1",
-                "course_id": str(self.course.id),
             }
             if not new_flagged:
                 params["update_all"] = False
@@ -1253,7 +1248,6 @@ class UpdateThreadTest(
             "action": "unflag",
             "user_id": "1",
             "update_all": bool(remove_all),
-            "course_id": str(self.course.id),
         }
 
         self.check_mock_called_with("update_thread_flag", -1, **params)
@@ -1319,14 +1313,12 @@ class UpdateThreadTest(
                     "thread_id": "test_thread",
                     "value": "up" if new_vote_status else "down",
                     "user_id": str(user1.id),
-                    "course_id": str(self.course.id),
                 }
                 self.check_mock_called_with("update_thread_votes", -1, **params)
             else:
                 params = {
                     "thread_id": "test_thread",
                     "user_id": str(user1.id),
-                    "course_id": str(self.course.id),
                 }
                 self.check_mock_called_with("delete_thread_vote", -1, **params)
             event_name, event_data = mock_emit.call_args[0]
@@ -1825,7 +1817,6 @@ class UpdateCommentTest(
         params = {
             "comment_id": "test_comment",
             "body": "Edited body",
-            "course_id": str(self.course.id),
             "user_id": str(self.user.id),
             "anonymous": False,
             "anonymous_to_peers": False,
@@ -1868,7 +1859,6 @@ class UpdateCommentTest(
                 "comment_id": "test_comment",
                 "action": "flag" if new_flagged else "unflag",
                 "user_id": "1",
-                "course_id": str(self.course.id),
             }
             if not new_flagged:
                 params["update_all"] = False
@@ -1933,7 +1923,6 @@ class UpdateCommentTest(
             "action": "unflag",
             "user_id": "1",
             "update_all": bool(remove_all),
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("update_comment_flag", -1, **params)
 
@@ -1995,14 +1984,12 @@ class UpdateCommentTest(
                     "comment_id": "test_comment",
                     "value": "up" if new_vote_status else "down",
                     "user_id": str(user1.id),
-                    "course_id": str(self.course.id),
                 }
                 self.check_mock_called_with("update_comment_votes", -1, **params)
             else:
                 params = {
                     "comment_id": "test_comment",
                     "user_id": str(user1.id),
-                    "course_id": str(self.course.id),
                 }
                 self.check_mock_called_with("delete_comment_vote", -1, **params)
 
@@ -2356,7 +2343,6 @@ class DeleteThreadTest(
         self.check_mock_called("delete_thread")
         params = {
             "thread_id": self.thread_id,
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("delete_thread", -1, **params)
 
@@ -2543,7 +2529,6 @@ class DeleteCommentTest(
         self.check_mock_called("delete_comment")
         params = {
             "comment_id": self.comment_id,
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("delete_comment", -1, **params)
 
@@ -3673,7 +3658,6 @@ class GetCommentListTest(
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with("get_thread", -1, **params)
 

--- a/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_serializers_v2.py
@@ -331,7 +331,6 @@ class CommentSerializerDeserializationTest(ForumsEnableMixin, ForumMockUtilsMixi
         self.save_and_reserialize({}, instance=self.existing_comment)
         parsed_body = {
             'body': 'Original body',
-            'course_id': str(self.course.id),
             'user_id': str(self.user.id),
             'anonymous': False,
             'anonymous_to_peers': False,

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -261,7 +261,6 @@ class ThreadViewSetPartialUpdateTest(
 
         params = {
             "thread_id": "test_thread",
-            "course_id": str(self.course.id),
             "commentable_id": "test_topic",
             "thread_type": "discussion",
             "title": "Test Title",
@@ -467,7 +466,6 @@ class CommentViewSetPartialUpdateTest(
         params = {
             "comment_id": "test_comment",
             "body": "Edited body",
-            "course_id": str(self.course.id),
             "user_id": str(self.user.id),
             "anonymous": False,
             "anonymous_to_peers": False,
@@ -944,7 +942,6 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         assert response.content == b''
         params = {
             "thread_id": self.thread_id,
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with('delete_thread', -1, **params)
 
@@ -1097,7 +1094,6 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            "course_id": str(self.course.id)
         }
         self.check_mock_called_with('get_thread', -1, **params)
 
@@ -1136,7 +1132,6 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "reverse_order": False,
                 "merge_question_type_responses": False,
             },
-            "course_id": str(self.course.id)
         }
         self.check_mock_called_with('get_thread', -1, **params)
 
@@ -1414,7 +1409,6 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
                 "reverse_order": True,
                 "merge_question_type_responses": False,
             },
-            "course_id": str(self.course.id)
         }
         self.check_mock_called_with('get_thread', -1, **params)
 
@@ -1452,7 +1446,6 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         assert response.content == b''
         params = {
             "comment_id": self.comment_id,
-            "course_id": str(self.course.id),
         }
         self.check_mock_called_with('delete_comment', -1, **params)
 

--- a/lms/djangoapps/discussion/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/tests/test_views_v2.py
@@ -411,7 +411,6 @@ class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase, ForumViewsUti
                 'reverse_order': False,
                 'merge_question_type_responses': False
             },
-            'course_id': str(self.course.id)
         }
         self.check_mock_called_with('get_thread', -1, **params)
 

--- a/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/comment.py
@@ -4,7 +4,7 @@ from bs4 import BeautifulSoup
 from openedx.core.djangoapps.django_comment_common.comment_client import models, settings
 
 from .thread import Thread
-from .utils import CommentClientRequestError, get_course_key
+from .utils import CommentClientRequestError
 from forum import api as forum_api
 
 
@@ -63,34 +63,29 @@ class Comment(models.Model):
             return super().url(action, params)
 
     def flagAbuse(self, user, voteable, course_id=None):
-        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if voteable.type == 'thread':
             response = forum_api.update_thread_flag(
                 thread_id=voteable.id,
                 action="flag",
                 user_id=user.id,
-                course_id=str(course_key),
             )
         elif voteable.type == 'comment':
             response = forum_api.update_comment_flag(
                 comment_id=voteable.id,
                 action="flag",
                 user_id=user.id,
-                course_id=str(course_key),
             )
         else:
             raise CommentClientRequestError("Can only flag/unflag threads or comments")
         voteable._update_from_response(response)
 
     def unFlagAbuse(self, user, voteable, removeAll, course_id=None):
-        course_key = get_course_key(self.attributes.get("course_id") or course_id)
         if voteable.type == "thread":
             response = forum_api.update_thread_flag(
                 thread_id=voteable.id,
                 action="unflag",
                 user_id=user.id,
                 update_all=bool(removeAll),
-                course_id=str(course_key),
             )
         elif voteable.type == 'comment':
             response = forum_api.update_comment_flag(
@@ -98,7 +93,6 @@ class Comment(models.Model):
                 action="unflag",
                 user_id=user.id,
                 update_all=bool(removeAll),
-                course_id=str(course_key),
             )
         else:
             raise CommentClientRequestError("Can flag/unflag for threads or comments")

--- a/openedx/core/djangoapps/django_comment_common/comment_client/subscriptions.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/subscriptions.py
@@ -22,7 +22,7 @@ class Subscription(models.Model):
     base_url = f"{settings.PREFIX}/threads"
 
     @classmethod
-    def fetch(cls, thread_id, course_id, query_params):
+    def fetch(cls, thread_id, query_params):
         """
         Fetches the subscriptions for a given thread_id
         """
@@ -34,12 +34,10 @@ class Subscription(models.Model):
         params.update(
             utils.strip_blank(utils.strip_none(query_params))
         )
-        course_key = utils.get_course_key(course_id)
         response = forum_api.get_thread_subscriptions(
             thread_id=thread_id,
             page=params["page"],
             per_page=params["per_page"],
-            course_id=str(course_key)
         )
         return utils.SubscriptionsPaginatedResult(
             collection=response.get('collection', []),


### PR DESCRIPTION
### Description
- Removed the now-unnecessary course_id parameter from forum-related functions. This parameter was originally introduced to differentiate between MongoDB- and MySQL-backed courses. Since the platform has fully migrated away from MongoDB, the distinction is no longer required.
- Updated associated tests to reflect the removal of course_id.