### PR TITLE
fix: use subscription endpoint

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api_v2.py
@@ -3301,7 +3301,7 @@ class GetThreadListTest(
         )
         expected_result.update({"text_search_rewrite": None})
         assert result == expected_result
-        self.check_mock_called("get_user_threads")
+        self.check_mock_called("get_user_subscriptions")
 
         params = {
             "user_id": str(self.user.id),
@@ -3310,7 +3310,7 @@ class GetThreadListTest(
             "page": 1,
             "per_page": 11,
         }
-        self.check_mock_called_with("get_user_threads", -1, **params)
+        self.check_mock_called_with("get_user_subscriptions", -1, **params)
 
     @ddt.data("unanswered", "unread")
     def test_view_query(self, query):

--- a/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_views_v2.py
@@ -725,7 +725,7 @@ class ThreadViewSetListTest(
         )
         expected_response.update({"text_search_rewrite": None})
         self.assert_response_correct(response, 200, expected_response)
-        self.check_mock_called("get_user_threads")
+        self.check_mock_called("get_user_subscriptions")
 
     @ddt.data(False, "false", "0")
     def test_following_false(self, following):

--- a/lms/djangoapps/discussion/rest_api/tests/utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/utils.py
@@ -682,7 +682,7 @@ class ForumMockUtilsMixin(MockForumApiMixin):
         self.set_mock_return_value('update_username', body)
 
     def register_subscribed_threads_response(self, user, threads, page, num_pages):
-        self.set_mock_return_value('get_user_threads', {
+        self.set_mock_return_value('get_user_subscriptions', {
             "collection": threads,
             "page": page,
             "num_pages": num_pages,

--- a/lms/djangoapps/discussion/tests/test_tasks_v2.py
+++ b/lms/djangoapps/discussion/tests/test_tasks_v2.py
@@ -123,7 +123,7 @@ class TaskTestCase(
         """mock threads and comments"""
         if subscribed_thread_ids:
             self.set_mock_side_effect(
-                "get_user_threads",
+                "get_user_subscriptions",
                 make_subscribed_threads_callback(subscribed_thread_ids, per_page),
             )
         if thread_data:

--- a/lms/djangoapps/discussion/tests/test_views_v2.py
+++ b/lms/djangoapps/discussion/tests/test_views_v2.py
@@ -286,6 +286,7 @@ class ForumViewsUtilsMixin(MockForumApiMixin):
             "search_threads",
             "get_user_active_threads",
             "get_user_threads",
+            "get_user_subscriptions",
         ]:
             self.set_mock_side_effect(
                 func_name,
@@ -864,7 +865,7 @@ class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, Content
 
 
 class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixinV2, ForumViewsUtilsMixin):  # lint-amnesty, pylint: disable=missing-class-docstring
-    function_name = "get_user_threads"
+    function_name = "get_user_subscriptions"
 
     @classmethod
     def setUpClass(cls):

--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -127,8 +127,10 @@ class User(models.Model):
             params["count_flagged"] = str_to_bool(count_flagged)
         if not params.get("course_id"):
             params["course_id"] = str(course_key)
+        if 'text' in params:
+            params.pop('text')
         params = _clean_forum_params(params)
-        response = forum_api.get_user_threads(**params)
+        response = forum_api.get_user_subscriptions(**params)
         return utils.CommentClientPaginatedResult(
             collection=response.get('collection', []),
             page=response.get('page', 1),


### PR DESCRIPTION
### Description

- Call get_user_subscriptions in the subscription endpoint instead of get_user_threads
- It fixes the following filter