### PR TITLE
fix: include error_code in PreventRegistration exception response

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -590,7 +590,7 @@ class RegistrationView(APIView):
             errors = {
                 "error_message": [{"user_message": str(exc)}],
             }
-            return self._create_response(request, errors, status_code=exc.status_code)
+            return self._create_response(request, errors, status_code=exc.status_code, error_code=exc.error_code)
 
         response = self._handle_duplicate_email_username(request, data)
         if response:


### PR DESCRIPTION
## Description
The Authn MFE relies on the `error_code` in API responses to display appropriate error messages to users. Although the PreventRegistration exception already supports `error_code`, it was not previously included in the API response payload.

This change ensures that `error_code` is returned in the response when a PreventRegistration exception is raised, allowing the frontend to handle errors more accurately.


`StudentLoginRequested` filter already does this but `StudentRegistrationRequested` does not
```
        try:
            possibly_authenticated_user = StudentLoginRequested.run_filter(user=possibly_authenticated_user)
        except StudentLoginRequested.PreventLogin as exc:
            raise AuthFailedError(
                str(exc), redirect_url=exc.redirect_to, error_code=exc.error_code, context=exc.context,
            ) from exc
```

### Authn MFE PR:
https://github.com/edly-io/frontend-app-authn/pull/15
