### PR TITLE
fix: password history count on unblocking a user.

### DIFF
--- a/openedx/features/edly/managers.py
+++ b/openedx/features/edly/managers.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 class PasswordHistoryManager(models.Manager):
     config = getattr(settings, 'PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG', {})
-    default_offset = config.get('PASSWORD_ROTATE_HISTORY_COUNT', 0)
+    default_offset = config.get('PASSWORD_ROTATE_HISTORY_COUNT', 4)
 
 
     def delete_expired(self, user, offset=None):


### PR DESCRIPTION
This PR fixes the last passwords not being validated when a user is unblocked after being blocked