### PR TITLE
feat: align rerun creator status permission with course creator status

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/course_rerun.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/course_rerun.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 from cms.djangoapps.contentstore.utils import get_course_rerun_context
 from cms.djangoapps.contentstore.rest_api.v1.serializers import CourseRerunSerializer
 from common.djangoapps.student.roles import GlobalStaff
+from edly_features_app.roles import GlobalCourseCreatorRole
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists, view_auth_classes
 from xmodule.modulestore.django import modulestore
 
@@ -60,10 +61,12 @@ class CourseRerunView(DeveloperErrorViewMixin, APIView):
         ```
         """
 
-        if not GlobalStaff().has_user(request.user):
+        #EDLYCUSTOM: Permit global course creators to access rerun status
+        course_key = CourseKey.from_string(course_id)
+
+        if not GlobalStaff().has_user(request.user) and not GlobalCourseCreatorRole(course_key.org).has_user(request.user):
             self.permission_denied(request)
 
-        course_key = CourseKey.from_string(course_id)
         with modulestore().bulk_operations(course_key):
             course_block = modulestore().get_course(course_key)
             course_rerun_context = get_course_rerun_context(course_key, course_block, request.user)

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -1746,7 +1746,8 @@ def get_home_context(request, no_course=False):
         'user': user,
         'request_course_creator_url': reverse('request_course_creator'),
         'course_creator_status': _get_course_creator_status(user),
-        'rerun_creator_status': GlobalStaff().has_user(user),
+        #EDLYCUSTOM: we need to have same permission for rerun creator as course creator
+        'rerun_creator_status': _get_course_creator_status(user) == 'granted',
         'allow_unicode_course_id': settings.FEATURES.get('ALLOW_UNICODE_COURSE_ID', False),
         'allow_course_reruns': settings.FEATURES.get('ALLOW_COURSE_RERUNS', True),
         'active_tab': 'courses',

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -23,6 +23,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
 from edly_features_app.filters import CoursesRequested, OrganizationsRequested
+from edly_features_app.roles import GlobalCourseCreatorRole
 from edx_django_utils.monitoring import function_trace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -318,9 +319,12 @@ def course_rerun_handler(request, course_key_string):
         html: return html page with form to rerun a course for the given course id
     """
     # Only global staff (PMs) are able to rerun courses during the soft launch
-    if not GlobalStaff().has_user(request.user):
-        raise PermissionDenied()
+    #EDLYCUSTOM: Permit global course creators to access rerun status
+
     course_key = CourseKey.from_string(course_key_string)
+    if not GlobalStaff().has_user(request.user) and not GlobalCourseCreatorRole(course_key.org).has_user(request.user):
+        raise PermissionDenied()
+
     with modulestore().bulk_operations(course_key):
         course_block = get_course_and_check_access(course_key, request.user, depth=3)
         if request.method == 'GET':
@@ -535,7 +539,9 @@ def _accessible_courses_list_from_groups(request):
 
     instructor_courses = UserBasedRole(request.user, CourseInstructorRole.ROLE).courses_with_role()
     staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
-    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses))
+    #EDLYCUSTOM: Include Global Course Creators of org as site courses 
+    site_courses = UserBasedRole(request.user, GlobalCourseCreatorRole.ROLE).courses_with_role()
+    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses | site_courses))
     courses_list = []
     course_keys = {}
 

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -97,6 +97,12 @@ def get_user_permissions(user, course_key, org=None, service_variant=None):
     # global staff, org instructors, and course instructors have all permissions:
     if GlobalStaff().has_user(user) or OrgInstructorRole(org=org).has_user(user):
         return all_perms
+
+    #EDLYCUSTOM: Provide all course permissions to Global Course Creators
+    from edly_features_app.roles import GlobalCourseCreatorRole
+    if GlobalCourseCreatorRole(org).has_user(user):
+        return all_perms
+
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
     # HACK: Limited Staff should not have studio read access. However, since many LMS views depend on the


### PR DESCRIPTION
## Description
This PR updates course rerun access to include staff with the Course Creator role, instead of restricting it to Administrators only. This brings rerun permissions in line with our Koa release.

## Ticket
[The rerun feature should be visible to staff users instead of super-users on teak env](https://projects.arbisoft.com/project/edly-product/task/7987)
