### PR TITLE
feat: add thumbnail file upload to video module

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -367,8 +367,8 @@ class VideoBlock(
 
         settings_service = self.runtime.service(self, 'settings')
 
-        poster = None
-        if edxval_api and self.edx_video_id:
+        poster = self.thumbnail or None
+        if not poster and edxval_api and self.edx_video_id:
             poster = edxval_api.get_course_video_image_url(
                 course_id=self.runtime.course_id.for_branch(None),
                 edx_video_id=self.edx_video_id.strip()
@@ -606,6 +606,7 @@ class VideoBlock(
             'translation'
         ).rstrip('/?')
         editable_fields['handout']['type'] = 'FileUploader'
+        editable_fields['thumbnail']['type'] = 'FileUploader'
 
         return editable_fields
 
@@ -717,6 +718,11 @@ class VideoBlock(
         if self.handout:
             ele = etree.Element('handout')
             ele.set('src', self.handout)
+            xml.append(ele)
+
+        if self.thumbnail:
+            ele = etree.Element('thumbnail')
+            ele.set('src', self.thumbnail)
             xml.append(ele)
 
         transcripts = {}
@@ -920,6 +926,10 @@ class VideoBlock(
         if handout is not None:
             field_data['handout'] = handout.get('src')
 
+        thumbnail = xml.find('thumbnail')
+        if thumbnail is not None:
+            field_data['thumbnail'] = thumbnail.get('src')
+
         transcripts = xml.findall('transcript')
         if transcripts:
             field_data['transcripts'] = {tr.get('language'): tr.get('src') for tr in transcripts}
@@ -949,11 +959,13 @@ class VideoBlock(
 
         course_id = getattr(id_generator, 'target_course_id', None)
         # Update the handout location with current course_id
-        if 'handout' in list(field_data.keys()) and course_id:
-            handout_location = StaticContent.get_location_from_path(field_data['handout'])
-            if isinstance(handout_location, AssetLocator):
-                handout_new_location = StaticContent.compute_location(course_id, handout_location.path)
-                field_data['handout'] = StaticContent.serialize_asset_key_with_slash(handout_new_location)
+        if course_id:
+            for asset_field in ('handout', 'thumbnail'):
+                if asset_field in field_data:
+                    asset_location = StaticContent.get_location_from_path(field_data[asset_field])
+                    if isinstance(asset_location, AssetLocator):
+                        new_location = StaticContent.compute_location(course_id, asset_location.path)
+                        field_data[asset_field] = StaticContent.serialize_asset_key_with_slash(new_location)
 
         # For backwards compatibility: Add `source` if XML doesn't have `download_video`
         # attribute.

--- a/common/lib/xmodule/xmodule/video_module/video_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/video_utils.py
@@ -84,6 +84,10 @@ def get_poster(video):
 
     Poster metadata is dict of youtube url for image thumbnail and edx logo
     """
+    thumbnail_url = getattr(video, 'thumbnail', '') or None
+    if thumbnail_url:
+        return OrderedDict({"url": thumbnail_url, "type": "thumbnail"})
+
     if not video.bumper.get("enabled"):
         return
 

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -179,6 +179,15 @@ class VideoFields(object):
         display_name=_("Upload Handout"),
         scope=Scope.settings,
     )
+    thumbnail = String(
+        help=_(
+            "Upload or link to an image that appears before the learner plays the video. "
+            "This thumbnail is shown in Studio previews and in the LMS."
+        ),
+        display_name=_("Thumbnail Image"),
+        scope=Scope.settings,
+        default=""
+    )
     only_on_web = Boolean(
         help=_(
             "Specify whether access to this video is limited to browsers only, or if it can be "

--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -181,7 +181,7 @@ class VideoFields(object):
     )
     thumbnail = String(
         help=_(
-            "Upload or link to an image that appears before the learner plays the video. "
+            "Upload an image that appears before the learner plays the video. "
             "This thumbnail is shown in Studio previews and in the LMS."
         ),
         display_name=_("Thumbnail Image"),


### PR DESCRIPTION
## Description
- Make use of existing poster logic to add thumbnail iamge
- Introduced a new 'thumbnail' field in VideoFields for uploading or linking an image.
- Updated VideoBlock to handle thumbnail display and data serialization.
- Enhanced get_poster function to return thumbnail URL if available.
- Adjusted asset location handling to include thumbnail alongside handout.


## Ticket
