### PR TITLE
chore: update to font-aweseom v6 compatible classes

### DIFF
--- a/common/lib/xmodule/xmodule/js/fixtures/video.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video.html
@@ -11,7 +11,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <div class="video-player">
               <iframe id="id"></iframe>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_all.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_all.html
@@ -12,7 +12,7 @@
           <div class="tc-wrapper">
             <article class="video-wrapper">
               <span tabindex="0" class="spinner" aria-hidden="false" aria-label="Loading video player"></span>
-              <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="Play video"></span>
+              <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="Play video"></span>
               <div class="video-player-pre"></div>
               <section class="video-player">
                 <div id="id"></div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_autoadvance.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_autoadvance.html
@@ -13,7 +13,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <iframe id="id"></iframe>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_autoadvance_disabled.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_autoadvance_disabled.html
@@ -13,7 +13,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <iframe id="id"></iframe>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_hls.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_hls.html
@@ -11,7 +11,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <div id="id"></div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_html5.html
@@ -11,7 +11,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <div id="id"></div>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_no_captions.html
@@ -11,7 +11,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <iframe id="id"></iframe>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_with_bumper.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_with_bumper.html
@@ -13,7 +13,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <iframe id="id"></iframe>

--- a/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/video_yt_multiple.html
@@ -11,7 +11,7 @@
         <div class="tc-wrapper">
           <article class="video-wrapper">
             <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
             <div class="video-player-pre"></div>
             <section class="video-player">
               <iframe id="id1"></iframe>

--- a/lms/templates/ux/reference/fragments/unit-fragment.html
+++ b/lms/templates/ux/reference/fragments/unit-fragment.html
@@ -266,7 +266,7 @@ tabindex="-1"
 &lt;div class="tc-wrapper"&gt;
 &lt;div class="video-wrapper"&gt;
 &lt;span tabindex="0" class="spinner" aria-hidden="false" aria-label="Loading video player"&gt;&lt;/span&gt;
-&lt;span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="Play video"&gt;&lt;/span&gt;
+&lt;span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="Play video"&gt;&lt;/span&gt;
 &lt;div class="video-player-pre"&gt;&lt;/div&gt;
 &lt;div class="video-player"&gt;
 &lt;div id="0b9e39477cf34507a7a48f74be381fdd"&gt;&lt;/div&gt;
@@ -673,7 +673,7 @@ null,
                     <div class="tc-wrapper">
                         <div class="video-wrapper">
                             <span tabindex="-1" class="spinner" aria-hidden="true" aria-label="Loading video player"></span>
-                            <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="Play video"></span>
+                            <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="Play video"></span>
                             <div class="video-player-pre"></div>
                             <div class="video-player">
                                 <iframe id="0b9e39477cf34507a7a48f74be381fdd" frameborder="0" allowfullscreen="1" title="YouTube video player" width="640" height="360" src="https://www.youtube.com/embed/b7xgknqkQk8?controls=0&amp;wmode=transparent&amp;rel=0&amp;showinfo=0&amp;enablejsapi=1&amp;modestbranding=1&amp;cc_load_policy=0&amp;html5=1&amp;origin=http%3A%2F%2Flocalhost%3A8000&amp;widgetid=1" tabindex="-1" style="height: 641.25px; width: 1140px; top: 19.875px; left: 0px;"></iframe>

--- a/lms/templates/video.html
+++ b/lms/templates/video.html
@@ -24,7 +24,7 @@ from openedx.core.djangolib.js_utils import (
     <div class="tc-wrapper">
       <div class="video-wrapper">
           <span tabindex="0" class="spinner" aria-hidden="false" aria-label="${_('Loading video player')}"></span>
-          <span tabindex="-1" class="btn-play fa fa-youtube-play fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
+          <span tabindex="-1" class="btn-play fa-brands fa-youtube fa-2x is-hidden" aria-hidden="true" aria-label="${_('Play video')}"></span>
           <div class="video-player-pre"></div>
           <div class="video-player">
               <div id="${id}"></div>


### PR DESCRIPTION
## Description
We are using font-awesome `v6.4.2` in our themes however the classes used by openedx are as per `v4.7.0`
This PR updated the classes so they are v6.4.2 compatible

