### PR TITLE
fix: use card image url in programs dashboard

### DIFF
--- a/lms/static/js/learner_dashboard/models/program_model.js
+++ b/lms/static/js/learner_dashboard/models/program_model.js
@@ -12,6 +12,7 @@ class ProgramModel extends Backbone.Model {
                 subtitle: data.subtitle,
                 authoring_organizations: data.authoring_organizations,
                 detailUrl: data.detail_url,
+                cardImageUrl: data.card_image_url,
                 xsmallBannerUrl: (data.banner_image && data.banner_image['x-small']) ? data.banner_image['x-small'].url : '',
                 smallBannerUrl: (data.banner_image && data.banner_image.small) ? data.banner_image.small.url : '',
                 mediumBannerUrl: (data.banner_image && data.banner_image.medium) ? data.banner_image.medium.url : '',

--- a/lms/templates/learner_dashboard/program_card.underscore
+++ b/lms/templates/learner_dashboard/program_card.underscore
@@ -57,7 +57,7 @@
             <source srcset="<%- smallBannerUrl %>" media="(max-width: <%- breakpoints.max.small %>)">
             <source srcset="<%- mediumBannerUrl %>" media="(max-width: <%- breakpoints.max.medium %>)">
             <source srcset="<%- xsmallBannerUrl %>" media="(max-width: <%- breakpoints.max.large %>)">
-            <img class="banner-image" srcset="<%- smallBannerUrl %>" alt="<%- interpolate(gettext('%(programName)s Home Page.'), {programName: title}, true)%>">
+            <img class="banner-image" src="<%- cardImageUrl %>" alt="<%- interpolate(gettext('%(programName)s Home Page.'), {programName: title}, true)%>">
         </picture>
     </div>
 </a>


### PR DESCRIPTION
## Description
The programs card images are broken since we do not use the banner_image. We use banner_image_url to save image in discovery. 

**NOTE:**
`card_image_url` has been used since it was being already sent by the api. This [PR](https://github.com/edly-io/edly-discovery-app/pull/8) patches `card_image_url` to return the value of `banner_image_url`