### PR TITLE
feat: add passed_timestamp to CourseGradeFactory for figures

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -30,6 +30,7 @@ class CourseGradeBase:
         letter_grade=None,
         passed=False,
         force_update_subsections=False,
+        passed_timestamp=None,
         last_updated=None
     ):
         self.user = user
@@ -43,6 +44,9 @@ class CourseGradeBase:
         self.force_update_subsections = force_update_subsections
 
         self.last_updated = last_updated
+
+        # EDLYCUSTOM: this timestamp is used to mark a course as completed in edly panel via figures LCGM
+        self.passed_timestamp = passed_timestamp
 
     def __str__(self):
         return 'Course Grade: percent: {}, letter_grade: {}, passed: {}'.format(

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -144,6 +144,7 @@ class CourseGradeFactory:
             persistent_grade.percent_grade,
             persistent_grade.letter_grade,
             persistent_grade.letter_grade != '',
+            passed_timestamp=persistent_grade.passed_timestamp,
             last_updated=persistent_grade.modified
         )
 


### PR DESCRIPTION
## Description
This update passes passed_timestamp CourseGradeFactory so it can be used by figures. Previously we were querying `PersistentCourseGrade` which was a lot of unnecessary overhead. Since this code executes on every learner for every course for every site. that is a lot of queries we can avoid this way.


## Legacy Figures changes
```
def course_grade(learner, course):
    """
    Compatibility function to retrieve course grades

    Returns the course grade for the specified learner and course
    """
    if RELEASE_LINE == 'ginkgo':
        course_grade = CourseGradeFactory().create(learner, course)
    else:  # Assume Hawthorn or greater
        course_grade = CourseGradeFactory().read(learner, course)

    persistent_course_grade = PersistentCourseGrade.objects.filter(user_id=learner.id, course_id=course.id).using(read_replica_or_default()).order_by('-modified').first()
    course_grade.passed_timestamp = persistent_course_grade.passed_timestamp if persistent_course_grade else None
    return course_grade
    
```

**Note:** Above code was not copied into `develop-teak` while rebasing which is why this issue was brought to our attention. This code is from KOA.