### PR TITLE
feat: add completion summary to GradeDataSerializer

### DIFF
--- a/lms/djangoapps/learner_home/serializers.py
+++ b/lms/djangoapps/learner_home/serializers.py
@@ -281,9 +281,17 @@ class GradeDataSerializer(serializers.Serializer):
     requires_context = True
 
     isPassing = serializers.SerializerMethodField()
+    completionSummary = serializers.SerializerMethodField()
 
     def get_isPassing(self, enrollment):
         return self.context.get("grade_statuses", {}).get(enrollment.course_id, False)
+
+    def get_completionSummary(self, enrollment):
+        summary = self.context.get("completion_summaries", {}).get(enrollment.course_id, {})
+        total = summary.get("complete_count", 0) + summary.get("incomplete_count", 0) + summary.get("locked_count", 0)
+        if not total:
+            return 0
+        return round(summary.get("complete_count", 0) / total * 100, 2)
 
 
 class CertificateSerializer(serializers.Serializer):

--- a/lms/djangoapps/learner_home/views.py
+++ b/lms/djangoapps/learner_home/views.py
@@ -47,6 +47,7 @@ from lms.djangoapps.bulk_email.models_api import is_bulk_email_feature_enabled
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import administrative_accesses_to_course_for_user
 from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
+from lms.djangoapps.courseware.courses import get_course_blocks_completion_summary
 from lms.djangoapps.learner_home.serializers import (
     LearnerDashboardSerializer,
 )
@@ -543,6 +544,12 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
         # Get social media sharing config
         course_share_urls = get_course_share_urls(course_enrollments)
 
+        # Get completion summaries (complete/incomplete/locked unit counts) per course
+        completion_summaries = {
+            enrollment.course_id: get_course_blocks_completion_summary(enrollment.course_id, user)
+            for enrollment in course_enrollments
+        }
+
         # Get credit availability
         user_credit_statuses = get_credit_statuses(user, course_enrollments)
 
@@ -564,6 +571,7 @@ class InitializeView(APIView):  # pylint: disable=unused-argument
             "course_optouts": course_optouts,
             "course_access_checks": course_access_checks,
             "credit_statuses": user_credit_statuses,
+            "completion_summaries": completion_summaries,
             "grade_statuses": grade_statuses,
             "resume_course_urls": resume_button_urls,
             "course_share_urls": course_share_urls,


### PR DESCRIPTION
This PR extends the Learner Home API by adding a `completionSummary` field to `GradeDataSerializer`, which exposes a learner's course completion as a percentage. In `views.py`, we import `get_course_blocks_completion_summary` and build a `completion_summaries` dictionary (keyed by `course_id`) for all active enrollments, passing it into the serializer context. The new `get_completionSummary()` method in the serializer sums `complete_count`, `incomplete_count`, and `locked_count` to derive a total unit count, returns `0` if there are no units (avoiding division by zero), and otherwise returns `round(complete_count / total * 100, 2)`. This enables the frontend to display a progress indicator alongside the existing `isPassing` status on the learner dashboard.