### PR TITLE
Redirect learners with incomplete biodata declaration to profile after login

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -255,7 +256,48 @@ def get_redirect_url_with_host(root_url, redirect_to):
     return redirect_to
 
 
-def get_next_url_for_login_page(request, include_host=False):
+def _has_submitted_biodata_declaration(user):
+    """
+    Return whether the biodata declaration has been completed for the user.
+
+    The biodata app is provided by the FBR plugin, so keep this lookup dynamic to
+    preserve the default Open edX behavior when that plugin is not installed.
+    """
+    try:
+        declaration_model = apps.get_model('biodata', 'Declaration')
+    except LookupError:
+        return True
+
+    try:
+        declaration = declaration_model.objects.only('is_submitted', 'confirmed').get(user=user)
+    except ObjectDoesNotExist:
+        return False
+
+    return declaration.is_submitted and declaration.confirmed
+
+
+def _get_biodata_profile_redirect_url(user):
+    """
+    Return the learner profile URL when biodata is incomplete, otherwise None.
+    """
+    if not getattr(user, 'username', None):
+        return None
+
+    if _has_submitted_biodata_declaration(user):
+        return None
+
+    profile_base_url = configuration_helpers.get_value(
+        'INDIGO_BIODATA_PROFILE_URL',
+        getattr(settings, 'PROFILE_MICROFRONTEND_URL', None),
+    ) or '/profile'
+
+    return '{profile_base_url}/u/{username}'.format(
+        profile_base_url=profile_base_url.rstrip('/'),
+        username=urllib.parse.quote(user.username),
+    )
+
+
+def get_next_url_for_login_page(request, include_host=False, user=None):
     """
     Determine the URL to redirect to following login/registration/third_party_auth
 
@@ -268,6 +310,10 @@ def get_next_url_for_login_page(request, include_host=False):
     redirection url (the default behaviour is to go to /dashboard).
 
     If THIRD_PARTY_AUTH_HINT is set, then `tpa_hint=<hint>` is added as a query parameter.
+
+    If the FBR biodata app is installed and the authenticated user has not
+    submitted and confirmed their biodata declaration, the user is sent to the
+    learner profile page before other destinations.
 
     This works with both GET and POST requests.
     """
@@ -302,6 +348,11 @@ def get_next_url_for_login_page(request, include_host=False):
             redirect_to = reverse('home')
             scheme = "https" if settings.HTTPS == "on" else "http"
             root_url = f'{scheme}://{settings.CMS_BASE}'
+
+    if settings.ROOT_URLCONF == 'lms.urls':
+        biodata_profile_redirect_url = _get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
+        if biodata_profile_redirect_url:
+            redirect_to = biodata_profile_redirect_url
 
     if any(param in request_params for param in POST_AUTH_PARAMS):
         # Before we redirect to next/dashboard, we need to handle auto-enrollment:

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -1,11 +1,13 @@
 """ Test Student helpers """
 
 import logging
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import ddt
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -151,3 +153,78 @@ class TestLoginHelper(TestCase):
             next_page = get_next_url_for_login_page(req)
 
         assert next_page == expected_url
+
+    @skip_unless_lms
+    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_redirects_to_profile_when_biodata_declaration_is_missing(self, mock_get_model):
+        """
+        Test incomplete biodata declaration redirects the authenticated user to their profile.
+        """
+        user = SimpleNamespace(username='test-user')
+        declaration_model = Mock()
+        declaration_model.objects.only.return_value.get.side_effect = ObjectDoesNotExist
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        assert next_page == 'http://profile-mfe/u/test-user'
+
+    @skip_unless_lms
+    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_redirects_to_profile_when_biodata_declaration_is_incomplete(self, mock_get_model):
+        """
+        Test unconfirmed biodata declaration redirects the authenticated user to their profile.
+        """
+        user = SimpleNamespace(username='test-user')
+        declaration = SimpleNamespace(is_submitted=True, confirmed=False)
+        declaration_model = Mock()
+        declaration_model.objects.only.return_value.get.return_value = declaration
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        assert next_page == 'http://profile-mfe/u/test-user'
+
+    @skip_unless_lms
+    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_keeps_login_redirect_when_biodata_declaration_is_complete(self, mock_get_model):
+        """
+        Test completed biodata declaration allows the normal login redirect.
+        """
+        user = SimpleNamespace(username='test-user')
+        declaration = SimpleNamespace(is_submitted=True, confirmed=True)
+        declaration_model = Mock()
+        declaration_model.objects.only.return_value.get.return_value = declaration
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        assert next_page == '/dashboard'
+
+    @skip_unless_lms
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_keeps_login_redirect_when_biodata_app_is_not_installed(self, mock_get_model):
+        """
+        Test default login redirect remains unchanged without the FBR biodata app.
+        """
+        user = SimpleNamespace(username='test-user')
+        mock_get_model.side_effect = LookupError
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        assert next_page == '/dashboard'

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -679,7 +679,11 @@ def login_user(request, api_version="v1"):  # pylint: disable=too-many-statement
         if is_user_third_party_authenticated:
             redirect_url = finish_auth_url
         elif should_redirect_to_authn_microfrontend():
-            next_url, root_url = get_next_url_for_login_page(request, include_host=True)
+            next_url, root_url = get_next_url_for_login_page(
+                request,
+                include_host=True,
+                user=possibly_authenticated_user,
+            )
             redirect_url = get_redirect_url_with_host(
                 root_url, enterprise_selection_page(request, possibly_authenticated_user, finish_auth_url or next_url)
             )


### PR DESCRIPTION
## Description

Updates the LMS login redirect flow so learners who have not completed their biodata declaration are redirected to their profile page after login.

The redirect now checks the FBR biodata `Declaration` record. If the declaration is missing, not submitted, or not confirmed, the learner is sent to their profile page instead of the normal post-login destination.

## Changes

- Added biodata declaration completion checks in `common.djangoapps.student.helpers`.
- Dynamically resolves the `biodata.Declaration` model so default Open edX behavior is preserved when the FBR biodata app is not installed.
- Redirects incomplete biodata users to:
  - `INDIGO_BIODATA_PROFILE_URL`, when configured
  - otherwise `PROFILE_MICROFRONTEND_URL`
  - otherwise `/profile`
- Passes the authenticated user into `get_next_url_for_login_page` during the authn login flow.
- Added tests for:
  - missing declaration
  - incomplete declaration
  - completed declaration
  - biodata app not installed