### PR TITLE
Fix Biodata Profile Redirect Before Learner Dashboard

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -16,7 +16,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist, PermissionDenied
 from django.core.validators import ValidationError
 from django.db import IntegrityError, ProgrammingError, transaction
 from django.urls import NoReverseMatch, reverse
@@ -269,11 +269,24 @@ def _has_submitted_biodata_declaration(user):
         return True
 
     try:
-        declaration = declaration_model.objects.only('is_submitted', 'confirmed').get(user=user)
+        declaration_model._meta.get_field('is_submitted')
+        has_is_submitted_field = True
+    except FieldDoesNotExist:
+        has_is_submitted_field = False
+
+    declaration_fields = ['confirmed']
+    if has_is_submitted_field:
+        declaration_fields.append('is_submitted')
+
+    try:
+        declaration = declaration_model.objects.only(*declaration_fields).get(user=user)
     except ObjectDoesNotExist:
         return False
 
-    return declaration.is_submitted and declaration.confirmed
+    if has_is_submitted_field:
+        return declaration.is_submitted and declaration.confirmed
+
+    return declaration.confirmed
 
 
 def get_biodata_profile_redirect_url(user):

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -303,9 +303,22 @@ def get_biodata_profile_redirect_url(user):
         'INDIGO_BIODATA_PROFILE_URL',
         getattr(settings, 'PROFILE_MICROFRONTEND_URL', None),
     ) or '/profile'
+    profile_base_url = profile_base_url.rstrip('/')
+    profile_base_url_parts = urllib.parse.urlsplit(profile_base_url)
+    profile_base_url_path = profile_base_url_parts.path.rstrip('/')
+
+    if profile_base_url_path.endswith('/u'):
+        profile_base_url_path = profile_base_url_path[:-2]
+        profile_base_url = urllib.parse.urlunsplit((
+            profile_base_url_parts.scheme,
+            profile_base_url_parts.netloc,
+            profile_base_url_path,
+            '',
+            '',
+        )).rstrip('/')
 
     return '{profile_base_url}/u/{username}'.format(
-        profile_base_url=profile_base_url.rstrip('/'),
+        profile_base_url=profile_base_url,
         username=urllib.parse.quote(user.username),
     )
 

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -276,7 +276,7 @@ def _has_submitted_biodata_declaration(user):
     return declaration.is_submitted and declaration.confirmed
 
 
-def _get_biodata_profile_redirect_url(user):
+def get_biodata_profile_redirect_url(user):
     """
     Return the learner profile URL when biodata is incomplete, otherwise None.
     """
@@ -350,7 +350,7 @@ def get_next_url_for_login_page(request, include_host=False, user=None):
             root_url = f'{scheme}://{settings.CMS_BASE}'
 
     if settings.ROOT_URLCONF == 'lms.urls':
-        biodata_profile_redirect_url = _get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
+        biodata_profile_redirect_url = get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
         if biodata_profile_redirect_url:
             redirect_to = biodata_profile_redirect_url
 

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -174,6 +174,29 @@ class TestLoginHelper(TestCase):
         assert next_page == 'http://profile-mfe/u/test-user'
 
     @skip_unless_lms
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_redirects_to_profile_when_biodata_profile_url_already_includes_user_path(self, mock_get_model):
+        """
+        Test profile URL config ending in /u does not duplicate the user path segment.
+        """
+        user = SimpleNamespace(username='fbrAdmin')
+        declaration_model = Mock()
+        declaration_model.objects.only.return_value.get.side_effect = ObjectDoesNotExist
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        with with_site_configuration_context(
+            configuration={
+                'INDIGO_BIODATA_PROFILE_URL': 'http://apps.local.openedx.io:1995/profile/u',
+            }
+        ):
+            next_page = get_next_url_for_login_page(req, user=user)
+
+        assert next_page == 'http://apps.local.openedx.io:1995/profile/u/fbrAdmin'
+
+    @skip_unless_lms
     @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
     @patch('common.djangoapps.student.helpers.apps.get_model')
     def test_redirects_to_profile_when_biodata_declaration_is_incomplete(self, mock_get_model):

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import ddt
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -211,6 +211,52 @@ class TestLoginHelper(TestCase):
 
         next_page = get_next_url_for_login_page(req, user=user)
 
+        assert next_page == '/dashboard'
+
+    @skip_unless_lms
+    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_redirects_to_profile_when_biodata_declaration_is_unconfirmed_without_submitted_field(
+        self,
+        mock_get_model,
+    ):
+        """
+        Test unconfirmed biodata declarations redirect when the model has no submitted field.
+        """
+        user = SimpleNamespace(username='test-user')
+        declaration = SimpleNamespace(confirmed=False)
+        declaration_model = Mock()
+        declaration_model._meta.get_field.side_effect = FieldDoesNotExist
+        declaration_model.objects.only.return_value.get.return_value = declaration
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        declaration_model.objects.only.assert_called_once_with('confirmed')
+        assert next_page == 'http://profile-mfe/u/test-user'
+
+    @skip_unless_lms
+    @patch('common.djangoapps.student.helpers.apps.get_model')
+    def test_keeps_login_redirect_when_biodata_declaration_is_confirmed_without_submitted_field(self, mock_get_model):
+        """
+        Test confirmed biodata declarations pass when the model has no submitted field.
+        """
+        user = SimpleNamespace(username='test-user')
+        declaration = SimpleNamespace(confirmed=True)
+        declaration_model = Mock()
+        declaration_model._meta.get_field.side_effect = FieldDoesNotExist
+        declaration_model.objects.only.return_value.get.return_value = declaration
+        mock_get_model.return_value = declaration_model
+
+        req = self.request.get(settings.LOGIN_URL)
+        req.META["HTTP_ACCEPT"] = "text/html"
+
+        next_page = get_next_url_for_login_page(req, user=user)
+
+        declaration_model.objects.only.assert_called_once_with('confirmed')
         assert next_page == '/dashboard'
 
     @skip_unless_lms

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -244,6 +244,24 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(self.path)
         self.assertRedirects(response, settings.LEARNER_HOME_MICROFRONTEND_URL, fetch_redirect_response=False)
 
+    @patch('common.djangoapps.student.views.dashboard.get_biodata_profile_redirect_url')
+    @patch('common.djangoapps.student.views.dashboard.learner_home_mfe_enabled')
+    def test_redirect_to_biodata_profile_before_learner_home(
+        self,
+        mock_learner_home_mfe_enabled,
+        mock_get_biodata_profile_redirect_url,
+    ):
+        """
+        If biodata is incomplete, redirect to learner profile before learner home MFE.
+        """
+        profile_url = 'http://profile-mfe/u/test-user'
+        mock_learner_home_mfe_enabled.return_value = True
+        mock_get_biodata_profile_redirect_url.return_value = profile_url
+
+        response = self.client.get(self.path)
+
+        self.assertRedirects(response, profile_url, fetch_redirect_response=False)
+
     def test_course_cert_available_message_after_course_end(self):
         course_key = CourseKey.from_string('course-v1:edX+DemoX+Demo_Course')
         course = CourseOverviewFactory.create(

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -55,7 +55,12 @@ from openedx.features.enterprise_support.api import (
 from openedx.features.enterprise_support.utils import is_enterprise_learner
 
 from common.djangoapps.student.api import COURSE_DASHBOARD_PLUGIN_VIEW_NAME
-from common.djangoapps.student.helpers import cert_info, check_verify_status_by_course, get_resume_urls_for_enrollments
+from common.djangoapps.student.helpers import (
+    cert_info,
+    check_verify_status_by_course,
+    get_biodata_profile_redirect_url,
+    get_resume_urls_for_enrollments,
+)
 from common.djangoapps.student.models import (
     AccountRecovery,
     CourseEnrollment,
@@ -529,6 +534,10 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     user = request.user
     if not UserProfile.objects.filter(user=user).exists():
         return redirect(settings.ACCOUNT_MICROFRONTEND_URL)
+
+    biodata_profile_redirect_url = get_biodata_profile_redirect_url(user)
+    if biodata_profile_redirect_url:
+        return redirect(biodata_profile_redirect_url)
 
     if learner_home_mfe_enabled():
         return redirect(settings.LEARNER_HOME_MICROFRONTEND_URL)


### PR DESCRIPTION
Ensures users with incomplete biodata are redirected to their learner profile before the learner dashboard MFE takes over. Also supports the installed FBR biodata declaration model and prevents duplicate `/u` path segments when the configured profile URL already ends with `/u`.