### PR TITLE
Revert changes merged after PR #730 from ulmo/fbr

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -12,7 +12,6 @@ from datetime import datetime
 
 from completion.exceptions import UnavailableCompletionData
 from completion.utilities import get_key_to_last_completed_block
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -256,48 +255,7 @@ def get_redirect_url_with_host(root_url, redirect_to):
     return redirect_to
 
 
-def _has_submitted_biodata_declaration(user):
-    """
-    Return whether the biodata declaration has been completed for the user.
-
-    The biodata app is provided by the FBR plugin, so keep this lookup dynamic to
-    preserve the default Open edX behavior when that plugin is not installed.
-    """
-    try:
-        declaration_model = apps.get_model('biodata', 'Declaration')
-    except LookupError:
-        return True
-
-    try:
-        declaration = declaration_model.objects.only('is_submitted', 'confirmed').get(user=user)
-    except ObjectDoesNotExist:
-        return False
-
-    return declaration.is_submitted and declaration.confirmed
-
-
-def _get_biodata_profile_redirect_url(user):
-    """
-    Return the learner profile URL when biodata is incomplete, otherwise None.
-    """
-    if not getattr(user, 'username', None):
-        return None
-
-    if _has_submitted_biodata_declaration(user):
-        return None
-
-    profile_base_url = configuration_helpers.get_value(
-        'INDIGO_BIODATA_PROFILE_URL',
-        getattr(settings, 'PROFILE_MICROFRONTEND_URL', None),
-    ) or '/profile'
-
-    return '{profile_base_url}/u/{username}'.format(
-        profile_base_url=profile_base_url.rstrip('/'),
-        username=urllib.parse.quote(user.username),
-    )
-
-
-def get_next_url_for_login_page(request, include_host=False, user=None):
+def get_next_url_for_login_page(request, include_host=False):
     """
     Determine the URL to redirect to following login/registration/third_party_auth
 
@@ -310,10 +268,6 @@ def get_next_url_for_login_page(request, include_host=False, user=None):
     redirection url (the default behaviour is to go to /dashboard).
 
     If THIRD_PARTY_AUTH_HINT is set, then `tpa_hint=<hint>` is added as a query parameter.
-
-    If the FBR biodata app is installed and the authenticated user has not
-    submitted and confirmed their biodata declaration, the user is sent to the
-    learner profile page before other destinations.
 
     This works with both GET and POST requests.
     """
@@ -348,11 +302,6 @@ def get_next_url_for_login_page(request, include_host=False, user=None):
             redirect_to = reverse('home')
             scheme = "https" if settings.HTTPS == "on" else "http"
             root_url = f'{scheme}://{settings.CMS_BASE}'
-
-    if settings.ROOT_URLCONF == 'lms.urls':
-        biodata_profile_redirect_url = _get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
-        if biodata_profile_redirect_url:
-            redirect_to = biodata_profile_redirect_url
 
     if any(param in request_params for param in POST_AUTH_PARAMS):
         # Before we redirect to next/dashboard, we need to handle auto-enrollment:

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -16,7 +16,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.validators import ValidationError
 from django.db import IntegrityError, ProgrammingError, transaction
 from django.urls import NoReverseMatch, reverse
@@ -269,27 +269,14 @@ def _has_submitted_biodata_declaration(user):
         return True
 
     try:
-        declaration_model._meta.get_field('is_submitted')
-        has_is_submitted_field = True
-    except FieldDoesNotExist:
-        has_is_submitted_field = False
-
-    declaration_fields = ['confirmed']
-    if has_is_submitted_field:
-        declaration_fields.append('is_submitted')
-
-    try:
-        declaration = declaration_model.objects.only(*declaration_fields).get(user=user)
+        declaration = declaration_model.objects.only('is_submitted', 'confirmed').get(user=user)
     except ObjectDoesNotExist:
         return False
 
-    if has_is_submitted_field:
-        return declaration.is_submitted and declaration.confirmed
-
-    return declaration.confirmed
+    return declaration.is_submitted and declaration.confirmed
 
 
-def get_biodata_profile_redirect_url(user):
+def _get_biodata_profile_redirect_url(user):
     """
     Return the learner profile URL when biodata is incomplete, otherwise None.
     """
@@ -303,22 +290,9 @@ def get_biodata_profile_redirect_url(user):
         'INDIGO_BIODATA_PROFILE_URL',
         getattr(settings, 'PROFILE_MICROFRONTEND_URL', None),
     ) or '/profile'
-    profile_base_url = profile_base_url.rstrip('/')
-    profile_base_url_parts = urllib.parse.urlsplit(profile_base_url)
-    profile_base_url_path = profile_base_url_parts.path.rstrip('/')
-
-    if profile_base_url_path.endswith('/u'):
-        profile_base_url_path = profile_base_url_path[:-2]
-        profile_base_url = urllib.parse.urlunsplit((
-            profile_base_url_parts.scheme,
-            profile_base_url_parts.netloc,
-            profile_base_url_path,
-            '',
-            '',
-        )).rstrip('/')
 
     return '{profile_base_url}/u/{username}'.format(
-        profile_base_url=profile_base_url,
+        profile_base_url=profile_base_url.rstrip('/'),
         username=urllib.parse.quote(user.username),
     )
 
@@ -376,7 +350,7 @@ def get_next_url_for_login_page(request, include_host=False, user=None):
             root_url = f'{scheme}://{settings.CMS_BASE}'
 
     if settings.ROOT_URLCONF == 'lms.urls':
-        biodata_profile_redirect_url = get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
+        biodata_profile_redirect_url = _get_biodata_profile_redirect_url(user or getattr(request, 'user', None))
         if biodata_profile_redirect_url:
             redirect_to = biodata_profile_redirect_url
 

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -1,13 +1,11 @@
 """ Test Student helpers """
 
 import logging
-from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import ddt
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -153,78 +151,3 @@ class TestLoginHelper(TestCase):
             next_page = get_next_url_for_login_page(req)
 
         assert next_page == expected_url
-
-    @skip_unless_lms
-    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_redirects_to_profile_when_biodata_declaration_is_missing(self, mock_get_model):
-        """
-        Test incomplete biodata declaration redirects the authenticated user to their profile.
-        """
-        user = SimpleNamespace(username='test-user')
-        declaration_model = Mock()
-        declaration_model.objects.only.return_value.get.side_effect = ObjectDoesNotExist
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        assert next_page == 'http://profile-mfe/u/test-user'
-
-    @skip_unless_lms
-    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_redirects_to_profile_when_biodata_declaration_is_incomplete(self, mock_get_model):
-        """
-        Test unconfirmed biodata declaration redirects the authenticated user to their profile.
-        """
-        user = SimpleNamespace(username='test-user')
-        declaration = SimpleNamespace(is_submitted=True, confirmed=False)
-        declaration_model = Mock()
-        declaration_model.objects.only.return_value.get.return_value = declaration
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        assert next_page == 'http://profile-mfe/u/test-user'
-
-    @skip_unless_lms
-    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_keeps_login_redirect_when_biodata_declaration_is_complete(self, mock_get_model):
-        """
-        Test completed biodata declaration allows the normal login redirect.
-        """
-        user = SimpleNamespace(username='test-user')
-        declaration = SimpleNamespace(is_submitted=True, confirmed=True)
-        declaration_model = Mock()
-        declaration_model.objects.only.return_value.get.return_value = declaration
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        assert next_page == '/dashboard'
-
-    @skip_unless_lms
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_keeps_login_redirect_when_biodata_app_is_not_installed(self, mock_get_model):
-        """
-        Test default login redirect remains unchanged without the FBR biodata app.
-        """
-        user = SimpleNamespace(username='test-user')
-        mock_get_model.side_effect = LookupError
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        assert next_page == '/dashboard'

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import ddt
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -174,29 +174,6 @@ class TestLoginHelper(TestCase):
         assert next_page == 'http://profile-mfe/u/test-user'
 
     @skip_unless_lms
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_redirects_to_profile_when_biodata_profile_url_already_includes_user_path(self, mock_get_model):
-        """
-        Test profile URL config ending in /u does not duplicate the user path segment.
-        """
-        user = SimpleNamespace(username='fbrAdmin')
-        declaration_model = Mock()
-        declaration_model.objects.only.return_value.get.side_effect = ObjectDoesNotExist
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        with with_site_configuration_context(
-            configuration={
-                'INDIGO_BIODATA_PROFILE_URL': 'http://apps.local.openedx.io:1995/profile/u',
-            }
-        ):
-            next_page = get_next_url_for_login_page(req, user=user)
-
-        assert next_page == 'http://apps.local.openedx.io:1995/profile/u/fbrAdmin'
-
-    @skip_unless_lms
     @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
     @patch('common.djangoapps.student.helpers.apps.get_model')
     def test_redirects_to_profile_when_biodata_declaration_is_incomplete(self, mock_get_model):
@@ -234,52 +211,6 @@ class TestLoginHelper(TestCase):
 
         next_page = get_next_url_for_login_page(req, user=user)
 
-        assert next_page == '/dashboard'
-
-    @skip_unless_lms
-    @override_settings(PROFILE_MICROFRONTEND_URL='http://profile-mfe')
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_redirects_to_profile_when_biodata_declaration_is_unconfirmed_without_submitted_field(
-        self,
-        mock_get_model,
-    ):
-        """
-        Test unconfirmed biodata declarations redirect when the model has no submitted field.
-        """
-        user = SimpleNamespace(username='test-user')
-        declaration = SimpleNamespace(confirmed=False)
-        declaration_model = Mock()
-        declaration_model._meta.get_field.side_effect = FieldDoesNotExist
-        declaration_model.objects.only.return_value.get.return_value = declaration
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        declaration_model.objects.only.assert_called_once_with('confirmed')
-        assert next_page == 'http://profile-mfe/u/test-user'
-
-    @skip_unless_lms
-    @patch('common.djangoapps.student.helpers.apps.get_model')
-    def test_keeps_login_redirect_when_biodata_declaration_is_confirmed_without_submitted_field(self, mock_get_model):
-        """
-        Test confirmed biodata declarations pass when the model has no submitted field.
-        """
-        user = SimpleNamespace(username='test-user')
-        declaration = SimpleNamespace(confirmed=True)
-        declaration_model = Mock()
-        declaration_model._meta.get_field.side_effect = FieldDoesNotExist
-        declaration_model.objects.only.return_value.get.return_value = declaration
-        mock_get_model.return_value = declaration_model
-
-        req = self.request.get(settings.LOGIN_URL)
-        req.META["HTTP_ACCEPT"] = "text/html"
-
-        next_page = get_next_url_for_login_page(req, user=user)
-
-        declaration_model.objects.only.assert_called_once_with('confirmed')
         assert next_page == '/dashboard'
 
     @skip_unless_lms

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -244,24 +244,6 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         response = self.client.get(self.path)
         self.assertRedirects(response, settings.LEARNER_HOME_MICROFRONTEND_URL, fetch_redirect_response=False)
 
-    @patch('common.djangoapps.student.views.dashboard.get_biodata_profile_redirect_url')
-    @patch('common.djangoapps.student.views.dashboard.learner_home_mfe_enabled')
-    def test_redirect_to_biodata_profile_before_learner_home(
-        self,
-        mock_learner_home_mfe_enabled,
-        mock_get_biodata_profile_redirect_url,
-    ):
-        """
-        If biodata is incomplete, redirect to learner profile before learner home MFE.
-        """
-        profile_url = 'http://profile-mfe/u/test-user'
-        mock_learner_home_mfe_enabled.return_value = True
-        mock_get_biodata_profile_redirect_url.return_value = profile_url
-
-        response = self.client.get(self.path)
-
-        self.assertRedirects(response, profile_url, fetch_redirect_response=False)
-
     def test_course_cert_available_message_after_course_end(self):
         course_key = CourseKey.from_string('course-v1:edX+DemoX+Demo_Course')
         course = CourseOverviewFactory.create(

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -55,12 +55,7 @@ from openedx.features.enterprise_support.api import (
 from openedx.features.enterprise_support.utils import is_enterprise_learner
 
 from common.djangoapps.student.api import COURSE_DASHBOARD_PLUGIN_VIEW_NAME
-from common.djangoapps.student.helpers import (
-    cert_info,
-    check_verify_status_by_course,
-    get_biodata_profile_redirect_url,
-    get_resume_urls_for_enrollments,
-)
+from common.djangoapps.student.helpers import cert_info, check_verify_status_by_course, get_resume_urls_for_enrollments
 from common.djangoapps.student.models import (
     AccountRecovery,
     CourseEnrollment,
@@ -534,10 +529,6 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     user = request.user
     if not UserProfile.objects.filter(user=user).exists():
         return redirect(settings.ACCOUNT_MICROFRONTEND_URL)
-
-    biodata_profile_redirect_url = get_biodata_profile_redirect_url(user)
-    if biodata_profile_redirect_url:
-        return redirect(biodata_profile_redirect_url)
 
     if learner_home_mfe_enabled():
         return redirect(settings.LEARNER_HOME_MICROFRONTEND_URL)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -679,11 +679,7 @@ def login_user(request, api_version="v1"):  # pylint: disable=too-many-statement
         if is_user_third_party_authenticated:
             redirect_url = finish_auth_url
         elif should_redirect_to_authn_microfrontend():
-            next_url, root_url = get_next_url_for_login_page(
-                request,
-                include_host=True,
-                user=possibly_authenticated_user,
-            )
+            next_url, root_url = get_next_url_for_login_page(request, include_host=True)
             redirect_url = get_redirect_url_with_host(
                 root_url, enterprise_selection_page(request, possibly_authenticated_user, finish_auth_url or next_url)
             )


### PR DESCRIPTION
## Summary

This PR reverts the changes that were merged after PR #730 on the `ulmo/fbr` branch.

The goal is to keep the branch state aligned with PR #730 and remove the later biodata dashboard/profile redirect changes that were merged on top of it.

## Changes

- Reverted PR #733: `Fix Biodata Profile Redirect Before Learner Dashboard`
- Reverted PR #731: `Redirect learners with incomplete biodata declaration to profile after login`
- Kept PR #730 changes intact
- Avoided force-updating the `ulmo/fbr` branch directly by using a separate revert branch
