### PR TITLE
[FC-0118] Contentstore Grading APIs ADR Implementation pt 2

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_authoring_grading.py
@@ -98,7 +98,7 @@ class TestAuthoringGradingViewSetUpdate(APITestCase):
         return_value=_MOCK_GRADING_MODEL,
     )
     @patch(
-        'openedx.core.lib.api.view_utils.CourseOverview.course_exists',
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
         return_value=True,
     )
     def test_staff_patch_updates_grading_returns_200(
@@ -132,7 +132,7 @@ class TestAuthoringGradingViewSetUpdate(APITestCase):
         return_value=_MOCK_GRADING_MODEL,
     )
     @patch(
-        'openedx.core.lib.api.view_utils.CourseOverview.course_exists',
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
         return_value=True,
     )
     def test_deprecated_post_alias_still_returns_200(
@@ -154,3 +154,71 @@ class TestAuthoringGradingViewSetUpdate(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_update.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ADR 0029 – Standardize Error Responses
+# ---------------------------------------------------------------------------
+
+_REQUIRED_ERROR_FIELDS = ("type", "title", "status", "detail", "instance")
+
+class TestAuthoringGradingViewSetErrorShape(APITestCase):
+    """
+    ADR 0029 – error response shape regression tests for AuthoringGradingViewSet.
+
+    Verifies that 404 error responses conform to the standardized JSON envelope
+    after removing DeveloperErrorViewMixin and replacing @verify_course_exists()
+    with inline NotFound raises.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.staff_user = UserFactory.create(is_staff=True)
+        self.client.force_authenticate(user=self.staff_user)
+        self.url = reverse(
+            'cms.djangoapps.contentstore:v0:authoring-grading-detail',
+            kwargs={'course_id': COURSE_ID},
+        )
+
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
+        return_value=False,
+    )
+    def test_nonexistent_course_returns_not_found_envelope(self, mock_exists):
+        """PATCH for a course that does not exist must return 404 with ADR 0029 envelope."""
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        for field in _REQUIRED_ERROR_FIELDS:
+            self.assertIn(field, response.data, f"ADR 0029: missing error field '{field}'")
+
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
+        return_value=False,
+    )
+    def test_not_found_error_type_uri(self, mock_exists):
+        """The ``type`` field must be the ADR 0029 not-found URI."""
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data.get('type'), 'https://docs.openedx.org/errors/not-found')
+
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
+        return_value=False,
+    )
+    def test_instance_field_is_request_path(self, mock_exists):
+        """The ``instance`` field must equal the request path."""
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data.get('instance'), self.url)
+
+    @patch(
+        'cms.djangoapps.contentstore.rest_api.v0.views.authoring_grading.CourseOverview.course_exists',
+        return_value=False,
+    )
+    def test_no_developer_message_in_error_body(self, mock_exists):
+        """Response must NOT contain the old DeveloperErrorViewMixin 'developer_message' key."""
+        response = self.client.patch(self.url, {}, content_type='application/json')
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn('developer_message', response.data)
+        self.assertNotIn('error_code', response.data)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/authoring_grading.py
@@ -1,8 +1,10 @@
 """ API Views for course grading settings """
 
 import edx_api_doc_tools as apidocs
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import viewsets
+from rest_framework.exceptions import NotFound  # ADR 0029
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -14,13 +16,13 @@ from rest_framework.permissions import IsAuthenticated
 
 from cms.djangoapps.contentstore.views.permissions import HasStudioReadAccess
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview  # ADR 0029
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, verify_course_exists
 from ..serializers import CourseGradingModelSerializer
 
 
 # ADR 0028 – consolidated from AuthoringGradingView
-class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
+class AuthoringGradingViewSet(viewsets.ViewSet):
     """
     ViewSet for getting and setting the grading settings for a course.
 
@@ -56,7 +58,6 @@ class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
             404: "The requested course does not exist.",
         },
     )
-    @verify_course_exists()
     def partial_update(self, request: Request, course_id: str):
         """
         Update a course's grading settings.
@@ -101,7 +102,12 @@ class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
 
         If the request is successful, an HTTP 200 "OK" response is returned.
         """
-        course_key = CourseKey.from_string(course_id)
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            raise NotFound("The provided course key cannot be parsed.")  # noqa: B904
+        if not CourseOverview.course_exists(course_key):
+            raise NotFound(f"Course {course_id} not found.")
 
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))
@@ -113,7 +119,7 @@ class AuthoringGradingViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
 
 # DEPRECATED (ADR 0028): Use AuthoringGradingViewSet instead.
 # Will be removed after one named release. Use PATCH grading/{course_id}/ via the router URL.
-class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
+class AuthoringGradingView(APIView):
     """
     View for getting and setting the advanced settings for a course.
     """
@@ -137,7 +143,6 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
             404: "The requested course does not exist.",
         },
     )
-    @verify_course_exists()
     def post(self, request: Request, course_id: str):
         """
         Update a course's grading.
@@ -182,7 +187,12 @@ class AuthoringGradingView(DeveloperErrorViewMixin, APIView):
 
         If the request is successful, an HTTP 200 "OK" response is returned,
         """
-        course_key = CourseKey.from_string(course_id)
+        try:
+            course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            raise NotFound("The provided course key cannot be parsed.")  # noqa: B904
+        if not CourseOverview.course_exists(course_key):
+            raise NotFound(f"Course {course_id} not found.")
 
         if 'minimum_grade_credit' in request.data:
             update_credit_course_requirements.delay(str(course_key))

--- a/openedx/core/lib/api/exceptions.py
+++ b/openedx/core/lib/api/exceptions.py
@@ -1,0 +1,151 @@
+"""
+ADR 0029 – Standardized error-response exception handler and helpers.
+
+Installs a platform-level DRF ``EXCEPTION_HANDLER`` that converts every
+API exception into a single, consistent JSON envelope::
+
+    {
+      "type":         "https://docs.openedx.org/errors/<slug>",
+      "title":        "Validation Error",
+      "status":       400,
+      "detail":       "The request body failed validation.",
+      "instance":     "/api/enrollment/v1/enrollment/",
+      "user_message": "...",   # optional – present only when set on exc
+      "errors":       {...}    # optional – present only for ValidationError
+    }
+
+The handler chains through the existing ``ignored_error_exception_handler``
+so that error logging / monitoring added by that handler is preserved.
+"""
+
+from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.response import Response
+
+
+# ---------------------------------------------------------------------------
+# Public exception classes
+# ---------------------------------------------------------------------------
+
+class Conflict(APIException):
+    """HTTP 409 Conflict — ADR 0029."""
+
+    status_code = 409
+    default_detail = "A conflict occurred."
+    default_code = "conflict"
+
+
+# ---------------------------------------------------------------------------
+# Central handler
+# ---------------------------------------------------------------------------
+
+def standardized_error_exception_handler(exc, context):
+    """
+    ADR 0029 – platform-level DRF exception handler.
+
+    Chains through ``ignored_error_exception_handler`` so that its error
+    logging / monitoring is preserved, then reformats the response to the
+    ADR 0029 envelope shape.
+
+    Returns a generic 500 body for unhandled exceptions so that stack
+    traces are never leaked to callers.
+    """
+    # Chain through the existing handler to preserve monitoring side-effects.
+    from openedx.core.lib.request_utils import ignored_error_exception_handler
+    response = ignored_error_exception_handler(exc, context)
+
+    if response is None:
+        # Unhandled exception (e.g. IntegrityError, unexpected 500).
+        # Always return a generic body — never expose stack traces.
+        return Response(
+            {
+                "type": "https://docs.openedx.org/errors/internal",
+                "title": "Internal Server Error",
+                "status": 500,
+                "detail": "An unexpected error occurred. Please try again later.",
+            },
+            status=500,
+        )
+
+    request = context.get("request")
+    body = {
+        "type": f"https://docs.openedx.org/errors/{_error_type(exc)}",
+        "title": _error_title(exc),
+        "status": response.status_code,
+        "detail": _flatten_detail(response.data),
+    }
+    if request:
+        body["instance"] = request.path
+    if hasattr(exc, "user_message") and exc.user_message:
+        body["user_message"] = exc.user_message
+    if isinstance(exc, ValidationError) and hasattr(exc, "detail"):
+        body["errors"] = _normalize_validation_errors(exc.detail)
+
+    response.data = body
+    response["Content-Type"] = "application/json"
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _error_type(exc):
+    """Map a DRF exception to an ADR 0029 error-type slug."""
+    from rest_framework.exceptions import (
+        AuthenticationFailed, NotAuthenticated, NotFound, PermissionDenied,
+        Throttled, ValidationError,
+    )
+    if isinstance(exc, (NotAuthenticated, AuthenticationFailed)):
+        return "authn"
+    if isinstance(exc, PermissionDenied):
+        return "authz"
+    if isinstance(exc, NotFound):
+        return "not-found"
+    if isinstance(exc, ValidationError):
+        return "validation"
+    if isinstance(exc, Throttled):
+        return "rate-limited"
+    if isinstance(exc, Conflict):
+        return "conflict"
+    return "internal"
+
+
+def _error_title(exc):
+    """Return a short, developer-facing title for the exception class."""
+    from rest_framework.exceptions import (
+        AuthenticationFailed, NotAuthenticated, NotFound, PermissionDenied,
+        Throttled, ValidationError,
+    )
+    _TITLES = {
+        NotAuthenticated: "Authentication Required",
+        AuthenticationFailed: "Authentication Failed",
+        PermissionDenied: "Permission Denied",
+        NotFound: "Not Found",
+        ValidationError: "Validation Error",
+        Throttled: "Too Many Requests",
+        Conflict: "Conflict",
+    }
+    return _TITLES.get(type(exc), "Internal Server Error")
+
+
+def _flatten_detail(data):
+    """Extract a single string from DRF's response.data for the ``detail`` field."""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict) and "detail" in data:
+        return str(data["detail"])
+    if isinstance(data, list) and data:
+        return str(data[0])
+    return str(data)
+
+
+def _normalize_validation_errors(detail):
+    """Normalize DRF ValidationError detail into ``{field: [msg, ...]}`` form."""
+    if isinstance(detail, dict):
+        return {
+            field: [str(e) for e in (errs if isinstance(errs, list) else [errs])]
+            for field, errs in detail.items()
+        }
+    if isinstance(detail, list):
+        return {"non_field_errors": [str(e) for e in detail]}
+    return {"non_field_errors": [str(detail)]}

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -820,7 +820,7 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-    'EXCEPTION_HANDLER': 'openedx.core.lib.request_utils.ignored_error_exception_handler',
+    'EXCEPTION_HANDLER': 'openedx.core.lib.api.exceptions.standardized_error_exception_handler',  # ADR 0029
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0029 – Standardize Error Responses

