### PR TITLE
[FC-0118] Contentstore Xblock APIs ADR Implementation pt 2

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock_viewset.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/tests/test_xblock_viewset.py
@@ -159,3 +159,70 @@ class TestXblockViewSetActions(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_handle.assert_called_once()
         self.assertEqual(mock_handle.call_args[0][1], None)
+
+# ---------------------------------------------------------------------------
+# ADR 0029 – Standardize Error Responses
+# ---------------------------------------------------------------------------
+
+_REQUIRED_ERROR_FIELDS = ("type", "title", "status", "detail", "instance")
+
+
+class TestXblockViewSetErrorShape(APITestCase):
+    """
+    ADR 0029 – error response shape regression tests for XblockViewSet.
+
+    Verifies that auth/permission error responses conform to the standardized
+    JSON envelope after removing DeveloperErrorViewMixin.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.client = APIClient()
+        self.detail_url = reverse(
+            'cms.djangoapps.contentstore:v0:xblock-detail',
+            kwargs={'usage_key_string': TEST_LOCATOR},
+        )
+        self.list_url = reverse('cms.djangoapps.contentstore:v0:xblock-list')
+
+    def test_unauthenticated_get_returns_standardized_401(self):
+        """Unauthenticated GET must return 401 with the ADR 0029 envelope."""
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        for field in _REQUIRED_ERROR_FIELDS:
+            self.assertIn(field, response.data, f"ADR 0029: missing error field '{field}'")
+
+    def test_unauthenticated_401_type_uri(self):
+        """The ``type`` field for 401 must be the ADR 0029 authn URI."""
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('type'), 'https://docs.openedx.org/errors/authn')
+
+    def test_non_author_get_returns_standardized_403(self):
+        """Authenticated non-author GET must return 403 with the ADR 0029 envelope."""
+        non_author = UserFactory.create()
+        self.client.force_authenticate(user=non_author)
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        for field in _REQUIRED_ERROR_FIELDS:
+            self.assertIn(field, response.data, f"ADR 0029: missing error field '{field}'")
+
+    def test_non_author_403_type_uri(self):
+        """The ``type`` field for 403 must be the ADR 0029 authz URI."""
+        non_author = UserFactory.create()
+        self.client.force_authenticate(user=non_author)
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get('type'), 'https://docs.openedx.org/errors/authz')
+
+    def test_error_body_has_no_developer_message(self):
+        """Error responses must NOT contain the old DeveloperErrorViewMixin 'developer_message' key."""
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertNotIn('developer_message', response.data)
+        self.assertNotIn('error_code', response.data)
+
+    def test_instance_field_is_request_path(self):
+        """The ``instance`` field must equal the request path."""
+        response = self.client.get(self.detail_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('instance'), self.detail_url)

--- a/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
+++ b/cms/djangoapps/contentstore/rest_api/v0/views/xblock.py
@@ -10,7 +10,6 @@ from django.views.decorators.csrf import csrf_exempt
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
-from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from rest_framework.permissions import IsAuthenticated
 from common.djangoapps.util.json_request import expect_json_in_class_view
 from opaque_keys import InvalidKeyError
@@ -28,7 +27,7 @@ handle_xblock = view_handlers.handle_xblock
 
 
 # ADR 0028 – consolidated from XblockView and XblockCreateView
-class XblockViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
+class XblockViewSet(viewsets.ViewSet):
     """
     ViewSet for xblock CRUD operations.
 
@@ -136,7 +135,7 @@ class XblockViewSet(DeveloperErrorViewMixin, viewsets.ViewSet):
 
 # DEPRECATED (ADR 0028): Use XblockViewSet instead.
 # Will be removed after one named release. Use GET/PUT/PATCH/DELETE xblock/{usage_key_string}/ instead.
-class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
+class XblockView(RetrieveUpdateDestroyAPIView):
     """
     Public rest API endpoints for the CMS API.
     course_id: required argument, needed to authorize course authors.
@@ -180,7 +179,7 @@ class XblockView(DeveloperErrorViewMixin, RetrieveUpdateDestroyAPIView):
 
 # DEPRECATED (ADR 0028): Use XblockViewSet instead.
 # Will be removed after one named release. Use POST xblock/ instead.
-class XblockCreateView(DeveloperErrorViewMixin, CreateAPIView):
+class XblockCreateView(CreateAPIView):
     """
     Public rest API endpoints for the CMS API.
     course_id: required argument, needed to authorize course authors.

--- a/openedx/core/lib/api/exceptions.py
+++ b/openedx/core/lib/api/exceptions.py
@@ -1,0 +1,148 @@
+"""
+ADR 0029 – Standardized error-response exception handler and helpers.
+
+Installs a platform-level DRF ``EXCEPTION_HANDLER`` that converts every
+API exception into a single, consistent JSON envelope::
+
+    {
+      "type":         "https://docs.openedx.org/errors/<slug>",
+      "title":        "Validation Error",
+      "status":       400,
+      "detail":       "The request body failed validation.",
+      "instance":     "/api/enrollment/v1/enrollment/",
+      "user_message": "...",   # optional – present only when set on exc
+      "errors":       {...}    # optional – present only for ValidationError
+    }
+
+The handler chains through the existing ``ignored_error_exception_handler``
+so that error logging / monitoring added by that handler is preserved.
+"""
+
+from rest_framework.exceptions import APIException, ValidationError
+from rest_framework.response import Response
+
+
+# ---------------------------------------------------------------------------
+# Public exception classes
+# ---------------------------------------------------------------------------
+
+class Conflict(APIException):
+    """HTTP 409 Conflict — ADR 0029."""
+
+    status_code = 409
+    default_detail = "A conflict occurred."
+    default_code = "conflict"
+
+
+# ---------------------------------------------------------------------------
+# Central handler
+# ---------------------------------------------------------------------------
+
+def standardized_error_exception_handler(exc, context):
+    """
+    ADR 0029 – platform-level DRF exception handler.
+
+    Chains through ``ignored_error_exception_handler`` so that its error
+    logging / monitoring is preserved, then reformats the response to the
+    ADR 0029 envelope shape.
+
+    Returns a generic 500 body for unhandled exceptions so that stack
+    traces are never leaked to callers.
+    """
+    from openedx.core.lib.request_utils import ignored_error_exception_handler
+    response = ignored_error_exception_handler(exc, context)
+
+    if response is None:
+        return Response(
+            {
+                "type": "https://docs.openedx.org/errors/internal",
+                "title": "Internal Server Error",
+                "status": 500,
+                "detail": "An unexpected error occurred. Please try again later.",
+            },
+            status=500,
+        )
+
+    request = context.get("request")
+    body = {
+        "type": f"https://docs.openedx.org/errors/{_error_type(exc)}",
+        "title": _error_title(exc),
+        "status": response.status_code,
+        "detail": _flatten_detail(response.data),
+    }
+    if request:
+        body["instance"] = request.path
+    if hasattr(exc, "user_message") and exc.user_message:
+        body["user_message"] = exc.user_message
+    if isinstance(exc, ValidationError) and hasattr(exc, "detail"):
+        body["errors"] = _normalize_validation_errors(exc.detail)
+
+    response.data = body
+    response["Content-Type"] = "application/json"
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _error_type(exc):
+    """Map a DRF exception to an ADR 0029 error-type slug."""
+    from rest_framework.exceptions import (
+        AuthenticationFailed, NotAuthenticated, NotFound, PermissionDenied,
+        Throttled, ValidationError,
+    )
+    if isinstance(exc, (NotAuthenticated, AuthenticationFailed)):
+        return "authn"
+    if isinstance(exc, PermissionDenied):
+        return "authz"
+    if isinstance(exc, NotFound):
+        return "not-found"
+    if isinstance(exc, ValidationError):
+        return "validation"
+    if isinstance(exc, Throttled):
+        return "rate-limited"
+    if isinstance(exc, Conflict):
+        return "conflict"
+    return "internal"
+
+
+def _error_title(exc):
+    """Return a short, developer-facing title for the exception class."""
+    from rest_framework.exceptions import (
+        AuthenticationFailed, NotAuthenticated, NotFound, PermissionDenied,
+        Throttled, ValidationError,
+    )
+    _TITLES = {
+        NotAuthenticated: "Authentication Required",
+        AuthenticationFailed: "Authentication Failed",
+        PermissionDenied: "Permission Denied",
+        NotFound: "Not Found",
+        ValidationError: "Validation Error",
+        Throttled: "Too Many Requests",
+        Conflict: "Conflict",
+    }
+    return _TITLES.get(type(exc), "Internal Server Error")
+
+
+def _flatten_detail(data):
+    """Extract a single string from DRF's response.data for the ``detail`` field."""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict) and "detail" in data:
+        return str(data["detail"])
+    if isinstance(data, list) and data:
+        return str(data[0])
+    return str(data)
+
+
+def _normalize_validation_errors(detail):
+    """Normalize DRF ValidationError detail into ``{field: [msg, ...]}`` form."""
+    if isinstance(detail, dict):
+        return {
+            field: [str(e) for e in (errs if isinstance(errs, list) else [errs])]
+            for field, errs in detail.items()
+        }
+    if isinstance(detail, list):
+        return {"non_field_errors": [str(e) for e in detail]}
+    return {"non_field_errors": [str(detail)]}

--- a/openedx/envs/common.py
+++ b/openedx/envs/common.py
@@ -820,7 +820,7 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
     ),
-    'EXCEPTION_HANDLER': 'openedx.core.lib.request_utils.ignored_error_exception_handler',
+    'EXCEPTION_HANDLER': 'openedx.core.lib.api.exceptions.standardized_error_exception_handler',  # ADR 0029
     'PAGE_SIZE': 10,
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {


### PR DESCRIPTION
### Description:

The FC-0118 initiative introduces a comprehensive standardization of APIs across the platform, guided by 15 newly defined Architectural Decision Records (ADRs). These ADRs collectively establish consistent patterns for serializers, permissions, error handling, pagination, filtering, authentication, versioning, and overall API design. Through this effort, existing endpoints are being refactored and aligned to ensure uniformity, improved developer experience, and long-term maintainability, while also reducing redundancy and inconsistencies across services.

### Checklist:

- [x] 0029 – Standardize Error Responses

