### PR TITLE
fix: scope Studio organization list to current tenant [EDLYPRODUCT-8305]

### DIFF
--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -7,6 +7,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 from organizations.api import get_organizations
 
+from edly_features_app.filters import OrganizationsRequested
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 
 
@@ -22,4 +23,7 @@ class OrganizationListView(View):
         """Returns organization list as json."""
         organizations = get_organizations()
         org_names_list = [(org["short_name"]) for org in organizations]
+        #EDLYCUSTOM: filter the org list down to the current tenant's organizations
+        # (same OrganizationsRequested filter used for the course-creation org dropdown).
+        org_names_list = OrganizationsRequested.run_filter(organizations=org_names_list)
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')  # lint-amnesty, pylint: disable=http-response-with-content-type-json


### PR DESCRIPTION
## Summary

The taxonomy **"Assign to organizations"** picker (Studio → Taxonomies → *Manage Organizations*) was listing **every edX organization across all tenants** instead of only the organizations belonging to the current tenant.

## Root cause

The taxonomy MFE org pickers (the *Manage Organizations* modal and the taxonomy-list org filter) both fetch their list from the Studio `/organizations` endpoint:

- MFE: `frontend-app-authoring/src/taxonomy/manage-orgs/data/api.ts` → `generic/data/api.ts:getOrganizations()` → `GET <STUDIO_BASE_URL>/organizations`
- Backend: `cms/djangoapps/contentstore/views/organization.py:OrganizationListView.get` → `organizations.api.get_organizations()` → **all orgs, unfiltered**

The course-creation org dropdown is already tenant-scoped because `cms/djangoapps/contentstore/views/course.py:get_organizations()` runs its list through the `OrganizationsRequested` openedx-filter (defined in `edly-features-app`, wired via `OPEN_EDX_FILTERS_CONFIG` → `io.edly.content_authoring.organization.list.requested.v1`). `OrganizationListView` simply never applied that filter.

## Fix

Apply the **same** `OrganizationsRequested.run_filter(...)` to the org list returned by `OrganizationListView`, exactly mirroring the existing course.py usage:

```python
organizations = get_organizations()
org_names_list = [(org["short_name"]) for org in organizations]
#EDLYCUSTOM: filter the org list down to the current tenant's organizations
# (same OrganizationsRequested filter used for the course-creation org dropdown).
org_names_list = OrganizationsRequested.run_filter(organizations=org_names_list)
```

- One line + the import; no behavioral change to the response shape (still a JSON list of `short_name` strings).
- The filter's pipeline (`OrganizationsRequestedPipeline`) **short-circuits and returns the input unchanged when `get_tenant_config()` is falsy**, so single-tenant / non-request / management-shell contexts are unaffected.
- Marked with `#EDLYCUSTOM` per the fork's core-change convention.

## Impact

Fixes the taxonomy org pickers **and** the taxonomy list-page org filter (both share `/organizations`). Any other consumer of `/organizations` now also respects tenant isolation, matching the behavior already in place for course creation.

## Testing

1. As a tenant admin (GlobalCourseCreator) on `red.apps.local.openedx.io`, open Studio → Taxonomies → a taxonomy → **Manage Organizations**.
2. Hard-refresh (org list is cached client-side by react-query `useOrganizationListData`).
3. "Add another organization" now lists **only the current tenant's orgs** (e.g. `red`), not all edX orgs.

> Note: verify in the UI — a `manage.py cms shell` check is not representative because the shell has no eox-tenant request context, so the filter passes through and returns all orgs.

## Ticket
https://projects.arbisoft.com/arbisoft/browse/EDLYPRODUCT-8305/