### PR TITLE
[TEMP] fix(EDLYPRODUCT-5411): cherry-pick upstream #38774

### DIFF
--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -4,6 +4,7 @@ This module contains signals / handlers related to programs.
 
 import logging
 
+from django.db import transaction
 from django.dispatch import receiver
 
 from openedx.core.djangoapps.content.course_overviews.signals import COURSE_PACING_CHANGED
@@ -86,7 +87,7 @@ def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs)
     # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
     from openedx.core.djangoapps.programs.tasks import award_course_certificate
 
-    award_course_certificate.delay(user.username, str(course_key))
+    transaction.on_commit(lambda: award_course_certificate.delay(user.username, str(course_key)))
 
 
 @receiver(COURSE_CERT_REVOKED)

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -142,7 +142,8 @@ class CertChangedReceiverTest(TestCase):
         assert mock_is_learner_issuance_enabled.call_count == 1
         assert mock_task.call_count == 0
 
-    def test_credentials_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+    @mock.patch("django.db.transaction.on_commit", side_effect=lambda f: f())
+    def test_credentials_enabled(self, mock_on_commit, mock_is_learner_issuance_enabled, mock_task):
         """
         Ensures that the receiver function invokes the expected celery task
         when the credentials API configuration is enabled.
@@ -152,23 +153,28 @@ class CertChangedReceiverTest(TestCase):
         handle_course_cert_changed(**self.signal_kwargs)
 
         assert mock_is_learner_issuance_enabled.call_count == 1
+        assert mock_on_commit.call_count == 1
         assert mock_task.call_count == 1
         assert mock_task.call_args[0] == (TEST_USERNAME, str(TEST_COURSE_KEY))
 
-    def test_records_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+    @mock.patch("django.db.transaction.on_commit", side_effect=lambda f: f())
+    def test_records_enabled(self, mock_on_commit, mock_is_learner_issuance_enabled, mock_task):
         mock_is_learner_issuance_enabled.return_value = True
 
         site_config = SiteConfigurationFactory.create(site_values={"course_org_filter": ["edX"]})
 
-        # Correctly sent
+        # Correctly sent (scheduled via transaction.on_commit)
         handle_course_cert_changed(**self.signal_kwargs)
+        assert mock_on_commit.called
         assert mock_task.called
+        mock_on_commit.reset_mock()
         mock_task.reset_mock()
 
         # Correctly not sent
         site_config.site_values["ENABLE_LEARNER_RECORDS"] = False
         site_config.save()
         handle_course_cert_changed(**self.signal_kwargs)
+        assert not mock_on_commit.called
         assert not mock_task.called
 
 


### PR DESCRIPTION
## Description
Cherry-picks https://github.com/openedx/openedx-platform/pull/38774

> ⚠️ **TEMPORARY — cherry-pick of upstream fix.** This is a cherry-pick of upstream openedx/edx-platform PR [#38774](https://github.com/openedx/edx-platform/pull/38774) (commit `432e02c`) onto `develop-ulmo`. **Remove this branch/commit once we catch up to an upstream release that already contains it.**

