### PR TITLE
feat: disable public account creation

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -73,6 +73,7 @@ FEATURES = FeaturesProxy(globals())
 
 ################################### FEATURES ###################################
 
+ALLOW_PUBLIC_ACCOUNT_CREATION = False
 CC_MERCHANT_NAME = Derived(lambda settings: settings.PLATFORM_NAME)
 
 # .. toggle_name: settings.DISPLAY_DEBUG_INFO_TO_STAFF


### PR DESCRIPTION
Disables public account creation at the LMS backend level by setting `ALLOW_PUBLIC_ACCOUNT_CREATION` to `False`.

The Authn MFE changes for removing registration from the UI are handled in a separate PR.