### PR TITLE
fix: presign video uploads with SigV4 for non us-east-1 buckets

### DIFF
--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -917,6 +917,16 @@ def storage_service_bucket():
             'aws_secret_access_key': settings.AWS_SECRET_ACCESS_KEY
         }
 
+    # boto2's S3Connection defaults to the global endpoint (s3.amazonaws.com)
+    # and SigV2. Buckets outside us-east-1 only accept SigV4 on their regional
+    # endpoint, so presigned PUTs fail with HTTP 400 ("Please use
+    # AWS4-HMAC-SHA256"). When a regional HOST is configured for the pipeline,
+    # target it and enable SigV4. Left unset, behaviour is unchanged.
+    host = settings.VIDEO_UPLOAD_PIPELINE.get('HOST')
+    if host:
+        os.environ['S3_USE_SIGV4'] = 'True'
+        params['host'] = host
+
     conn = S3Connection(**params)
 
     # We don't need to validate our bucket, it requires a very permissive IAM permission


### PR DESCRIPTION
## Problem

Studio video uploads fail on the S3 `PUT` with **HTTP 400** (`InvalidRequest`: "The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256").

`storage_service_bucket()` builds a boto2 `S3Connection` with no host or signature version, so it uses the **global `s3.amazonaws.com` endpoint** and **SigV2**. Buckets outside `us-east-1` (ours is `eu-central-1`) only accept **SigV4** on their regional endpoint, so the presigned URL is rejected.

## Change

When `VIDEO_UPLOAD_PIPELINE` defines a regional `HOST`, target it and enable SigV4:

```python
host = settings.VIDEO_UPLOAD_PIPELINE.get('HOST')
if host:
    os.environ['S3_USE_SIGV4'] = 'True'
    params['host'] = host
conn = S3Connection(**params)
```

- Scoped to the video-upload code path (not a global boto config change).
- **No behaviour change when `HOST` is unset** — existing `us-east-1` deployments keep working exactly as before.

## Companion changes

- `tutor-indigo` (`ulmo/rwaq`): supply `HOST` in the `VIDEO_UPLOAD_PIPELINE` dict from `RWAQ_VIDEO_S3_HOST` (default `s3.eu-central-1.amazonaws.com`). Replaces the plugin-level global-boto approach previously in edly-io/tutor-indigo#50.
- `rwaq-configurations`#21: AWS creds so the CMS can presign.
- The bucket needs CORS allowing `PUT` from the Studio origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)