### PR TITLE
fix: stop double HTML-escaping course name in enrollment emails

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -46,7 +46,6 @@ from openedx.core.djangoapps.ace_common.template_context import get_base_templat
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.models import UserPreference
-from openedx.core.djangolib.markup import Text
 from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user, is_email_retired
 from common.djangoapps.track.event_transaction_utils import (
     create_new_event_transaction_id,
@@ -411,7 +410,7 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
 
     protocol = 'https' if secure else 'http'
     course_key = course_key or text_type(course.id)
-    display_name = display_name or Text(course.display_name_with_default)
+    display_name = display_name or course.display_name_with_default
 
     if not site_name:
         site_name = configuration_helpers.get_value(
@@ -486,7 +485,7 @@ def send_mail_to_student(student, param_dict, language=None, context_vars=None, 
     if 'display_name' in param_dict:
         param_dict['course_name'] = param_dict['display_name']
     elif 'course' in param_dict:
-        param_dict['course_name'] = Text(param_dict['course'].display_name_with_default)
+        param_dict['course_name'] = param_dict['course'].display_name_with_default
 
     if not context_vars:
         param_dict['site_name'] = configuration_helpers.get_value(

--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -7,9 +7,10 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}Welcome to {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
@@ -51,9 +52,10 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}Sincerely yours, The {{ course_name }} Team{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
         </td>

--- a/lms/templates/instructor/edx_ace/addbetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/addbetatester/email/body.html
@@ -7,11 +7,12 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}
                     You have been invited to be a beta tester for {{ course_name }} at {{ site_name }}
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">

--- a/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedenroll/email/body.html
@@ -7,15 +7,17 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been invited to {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been invited to join {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
 
@@ -52,18 +54,20 @@
 
             <p style="color: rgba(0,0,0,.75);">
                 {% if auto_enroll %}
-                    {% filter force_escape %}
+                    {% autoescape off %}
+                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                     {% blocktrans %}Once you have registered and activated your account, you will see {{ course_name }} listed on your dashboard.{% endblocktrans %}
-                    {% endfilter %}
+                    {% endautoescape %}
                 {% elif course_about_url is not None %}
                     {% filter force_escape %}
                     {% blocktrans %}Once you have registered and activated your account, you will be able to access this course:{% endblocktrans %}
                     {% endfilter %}
                     {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_name course_cta_url=course_about_url %}
                 {% else %}
-                    {% filter force_escape %}
+                    {% autoescape off %}
+                    {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                     {% blocktrans %}You can then enroll in {{ course_name }}.{% endblocktrans %}
-                    {% endfilter %}
+                    {% endautoescape %}
                 {% endif %}
                 <br />
             </p>

--- a/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/allowedunenroll/email/body.html
@@ -7,15 +7,17 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been unenrolled from {{ course_name }}{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been unenrolled from the course {{ course_name }} by a member of the course staff. Please disregard the invitation previously sent.{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
 

--- a/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrolledunenroll/email/body.html
@@ -7,17 +7,19 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}
                     You have been unenrolled from {{ course_name }}
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been unenrolled from {{ course_name }} at {{ site_name }} by a member of the course staff. This course will no longer appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
 

--- a/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
+++ b/lms/templates/instructor/edx_ace/enrollenrolled/email/body.html
@@ -7,17 +7,19 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}
                     You have been enrolled in {{ course_name }}
                 {% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been enrolled in {{ course_name }} at {{ site_name }} by a member of the course staff. This course will now appear on your {{ site_name }} dashboard.{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
 

--- a/lms/templates/instructor/edx_ace/removebetatester/email/body.html
+++ b/lms/templates/instructor/edx_ace/removebetatester/email/body.html
@@ -7,15 +7,17 @@
     <tr>
         <td>
             <h1>
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }}{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
             </h1>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% filter force_escape %}
+                {% autoescape off %}
+                {# xss-lint: disable=django-blocktrans-missing-escape-filter #}
                 {% blocktrans %}You have been removed as a beta tester for {{ course_name }} at {{ site_name }} by a member of the course staff.{% endblocktrans %}
-                {% endfilter %}
+                {% endautoescape %}
                 <br />
             </p>
 


### PR DESCRIPTION
## Problem
Course titles containing `&` (or `<`, `>`, `"`) render as `CICT&amp;L` in instructor enrollment/beta emails. Reported on Koa for a course named *"Cambridge International Certificate in Teaching & Learning CICT&L 5881 Unit One (Pilot)"*.

## Root cause — two escapes stacked
1. **Python:** `get_email_params` / `send_mail_to_student` wrapped `course_name` in `Text()` (= `markupsafe.escape`) → `&` becomes `&amp;`.
2. **Template:** in the edx-ace HTML bodies, `{% blocktrans %}` runs under autoescape-on **and** was wrapped in `{% filter force_escape %}` → escapes a second time → `&amp;amp;` → renders `&amp;`.

The **subject** and **body.txt** use `{% autoescape off %}`, so removing `Text()` alone fixed those; the **HTML body** needed the template change too.

## Fix
- Drop the `Text()` wrapper on `course_name` (both call sites) — templates own the escaping.
- In the 7 instructor `body.html` templates, switch `course_name` blocktrans blocks from `{% filter force_escape %}` to `{% autoescape off %}` + xss-lint disable.

Backport of upstream [openedx/edx-platform#31995](https://github.com/openedx/edx-platform/pull/31995) ("fix subject email and body html code"), which fixed this on master but was never backported to the Koa release line. Cherry-pick isn't viable — that commit sits on 2023 master and conflicts across the whole repo on Koa.

## Coverage / notes
- All 7 instructor email types: allowed/enrolled enroll+unenroll, add/remove beta tester, account-creation-and-enrollment.
- Converts one block #31995 missed: account-creation *"Sincerely yours, The {course_name} Team"*.
- Leaves as upstream: the `addbetatester` `{% blocktrans asvar course_cta_text %}Visit {{ course_name }}{% endblocktrans %}` block — different render path (feeds the CTA include); upstream left it untouched.

## Testing
Not run locally — Koa devstack not up in this environment. Relies on CI. No behavior change beyond escaping of `course_name` in these emails.