### PR TITLE
fix: prevent rerun_course from deleting an already-succeeded course [EDLYPRODUCT-8393]

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -174,6 +174,11 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
 
     source_course_key = CourseKey.from_string(source_course_key_string)
     destination_course_key = CourseKey.from_string(destination_course_key_string)
+    # Tracks whether the rerun has already been marked succeeded, i.e. the destination course is a
+    # complete, usable course. Once this is True, the catch-all handler below must never delete the
+    # course out from under the user again -- any failure past this point is in auxiliary,
+    # non-essential post-processing (see the individually-guarded steps further down).
+    rerun_succeeded = False
     try:
         # deserialize the payload
         fields = deserialize_fields(fields) if fields else None
@@ -191,6 +196,7 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
 
         # update state: Succeeded
         CourseRerunState.objects.succeeded(course_key=destination_course_key)
+        rerun_succeeded = True
 
         COURSE_RERUN_COMPLETED.send_event(
             time=datetime.now(timezone.utc),
@@ -198,20 +204,47 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
                 course_key=destination_course_key
             )
         )
+
+        # The steps below are auxiliary/best-effort: the rerun has already succeeded and the course
+        # is live and usable at this point, so a failure here must not flip the state back to failed
+        # or delete the course. Each is wrapped and logged independently so a failure in one doesn't
+        # prevent the others from running.
+
         # call edxval to attach videos to the rerun
-        copy_course_videos(source_course_key, destination_course_key)
+        try:
+            copy_course_videos(source_course_key, destination_course_key)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                'Course Rerun: failed to copy videos from %s to %s. The rerun course itself is unaffected.',
+                source_course_key, destination_course_key,
+            )
 
         # Copy RestrictedCourse
-        restricted_course = RestrictedCourse.objects.filter(course_key=source_course_key).first()
+        try:
+            restricted_course = RestrictedCourse.objects.filter(course_key=source_course_key).first()
 
-        if restricted_course:
-            country_access_rules = CountryAccessRule.objects.filter(restricted_course=restricted_course)
-            new_restricted_course = clone_instance(restricted_course, {'course_key': destination_course_key})
-            for country_access_rule in country_access_rules:
-                clone_instance(country_access_rule, {'restricted_course': new_restricted_course})
+            if restricted_course:
+                country_access_rules = CountryAccessRule.objects.filter(restricted_course=restricted_course)
+                new_restricted_course = clone_instance(restricted_course, {'course_key': destination_course_key})
+                for country_access_rule in country_access_rules:
+                    clone_instance(country_access_rule, {'restricted_course': new_restricted_course})
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                'Course Rerun: failed to clone RestrictedCourse/CountryAccessRule from %s to %s. '
+                'The rerun course itself is unaffected.',
+                source_course_key, destination_course_key,
+            )
 
-        org_data = ensure_organization(destination_course_key.org)
-        add_organization_course(org_data, destination_course_key)
+        try:
+            org_data = ensure_organization(destination_course_key.org)
+            add_organization_course(org_data, destination_course_key)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception(
+                'Course Rerun: failed to link destination course %s to organization %s. The course exists '
+                'but may not be linked to its organization -- needs investigation.',
+                destination_course_key, destination_course_key.org,
+            )
+
         return "succeeded"
 
     except DuplicateCourseError:
@@ -226,12 +259,21 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
         CourseRerunState.objects.failed(course_key=destination_course_key)
         LOGGER.exception('Course Rerun Error')
 
-        try:
-            # cleanup any remnants of the course
-            modulestore().delete_course(destination_course_key, user_id)
-        except ItemNotFoundError:
-            # it's possible there was an error even before the course block was created
-            pass
+        if not rerun_succeeded:
+            try:
+                # cleanup any remnants of the course
+                modulestore().delete_course(destination_course_key, user_id)
+            except ItemNotFoundError:
+                # it's possible there was an error even before the course block was created
+                pass
+        else:
+            # The course was already fully cloned and marked succeeded before this exception was
+            # raised -- it's a valid, usable course. Do not delete it; just log for investigation.
+            LOGGER.exception(
+                'Course Rerun: destination course %s already succeeded before this error was raised; '
+                'preserving the course instead of deleting it.',
+                destination_course_key,
+            )
 
         return "exception: " + str(exc)
 

--- a/cms/djangoapps/contentstore/tests/test_clone_course.py
+++ b/cms/djangoapps/contentstore/tests/test_clone_course.py
@@ -141,3 +141,91 @@ class CloneCourseTest(CourseTestCase):
                 course_key=split_course4_id,
                 state=CourseRerunUIStateManager.State.FAILED
             )
+
+    def test_rerun_course_auxiliary_step_failure_does_not_delete_course(self):
+        """
+        Regression test for EDLYPRODUCT-8393: if an auxiliary, post-succeeded step (e.g. linking the
+        destination course to its organization) raises, the rerun must still be reported as
+        "succeeded" and the already-cloned course must NOT be deleted.
+        """
+        org = 'edX'
+        course_number = 'CS101'
+        course_run = '2015_Q1'
+        display_name = 'rerun'
+
+        split_course = CourseFactory.create(
+            org=org,
+            number=course_number,
+            run=course_run,
+            display_name=display_name,
+            default_store=ModuleStoreEnum.Type.split
+        )
+
+        rerun_course_id = CourseLocator(org=org, course=course_number, run="rerun_aux_failure")
+        fields = {'display_name': 'rerun'}
+        CourseRerunState.objects.initiated(split_course.id, rerun_course_id, self.user, fields['display_name'])
+
+        with patch(
+            'cms.djangoapps.contentstore.tasks.add_organization_course',
+            Mock(side_effect=Exception('org link boom!')),
+        ):
+            result = rerun_course.delay(
+                str(split_course.id), str(rerun_course_id), self.user.id,
+                json.dumps(fields, cls=EdxJSONEncoder)
+            )
+
+        # The failure in the auxiliary org-linking step must not surface as a task failure...
+        self.assertEqual(result.get(), "succeeded")
+        # ...the rerun state must remain SUCCEEDED...
+        rerun_state = CourseRerunState.objects.find_first(course_key=rerun_course_id)
+        self.assertEqual(rerun_state.state, CourseRerunUIStateManager.State.SUCCEEDED)
+        # ...and the course itself must still exist and be usable.
+        self.assertIsNotNone(self.store.get_course(rerun_course_id), "Course was deleted after an auxiliary failure")
+
+    def test_rerun_course_post_succeeded_failure_preserves_course(self):
+        """
+        Regression test for EDLYPRODUCT-8393: even a failure that isn't in one of the individually
+        wrapped auxiliary steps -- as long as it happens after the rerun has already been marked
+        succeeded -- must not delete the already-cloned, already-usable course. The rerun is still
+        reported/marked as failed (something genuinely went wrong and should be surfaced), but the
+        course itself is preserved rather than destroyed.
+        """
+        org = 'edX'
+        course_number = 'CS101'
+        course_run = '2015_Q1'
+        display_name = 'rerun'
+
+        split_course = CourseFactory.create(
+            org=org,
+            number=course_number,
+            run=course_run,
+            display_name=display_name,
+            default_store=ModuleStoreEnum.Type.split
+        )
+
+        rerun_course_id = CourseLocator(org=org, course=course_number, run="rerun_post_succeeded_failure")
+        fields = {'display_name': 'rerun'}
+        CourseRerunState.objects.initiated(split_course.id, rerun_course_id, self.user, fields['display_name'])
+
+        with patch(
+            'cms.djangoapps.contentstore.tasks.COURSE_RERUN_COMPLETED.send_event',
+            Mock(side_effect=Exception('event bus boom!')),
+        ):
+            result = rerun_course.delay(
+                str(split_course.id), str(rerun_course_id), self.user.id,
+                json.dumps(fields, cls=EdxJSONEncoder)
+            )
+
+        # The task itself surfaces the failure...
+        self.assertIn("exception: ", result.get())
+        # ...and the rerun state is (correctly) marked failed, since something genuinely broke...
+        CourseRerunState.objects.find_first(
+            course_key=rerun_course_id,
+            state=CourseRerunUIStateManager.State.FAILED
+        )
+        # ...but the course was already fully cloned and marked succeeded before the failure, so it
+        # must NOT be deleted.
+        self.assertIsNotNone(
+            self.store.get_course(rerun_course_id),
+            "Course was deleted even though it had already succeeded before the failure"
+        )

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -22,6 +22,7 @@ from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
 from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from common.djangoapps.course_action_state.managers import CourseRerunUIStateManager
 from common.djangoapps.course_action_state.models import CourseRerunState
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.course_apps.toggles import EXAMS_IDA
@@ -208,6 +209,34 @@ class RerunCourseTaskTestCase(CourseTestCase):  # lint-amnesty, pylint: disable=
         # Verify the OrganizationCourse is cloned with a different org
         self.assertEqual(OrganizationCourse.objects.count(), 2)
         OrganizationCourse.objects.get(course_id=new_course_id, organization__short_name='neworg')
+
+    def test_auxiliary_step_failure_does_not_delete_course(self):
+        """
+        Regression test for EDLYPRODUCT-8393.
+
+        If an auxiliary/best-effort post-succeeded step (video copy, RestrictedCourse clone, or
+        organization linking) raises, the task must still report "succeeded", the CourseRerunState
+        must remain SUCCEEDED, and the already-cloned course must remain retrievable from the
+        modulestore -- it must NOT be deleted.
+        """
+        old_course_key = self.course.id
+        new_course_key = CourseLocator(org=old_course_key.org, course=old_course_key.course, run='rerun')
+
+        CourseRerunState.objects.initiated(old_course_key, new_course_key, self.user, 'Test Re-run')
+
+        with mock.patch(
+            'edxval.api.copy_course_videos',
+            side_effect=Exception('edxval boom!'),
+        ):
+            result = rerun_course(str(old_course_key), str(new_course_key), self.user.id)
+
+        self.assertEqual(result, "succeeded")
+        rerun_state = CourseRerunState.objects.find_first(course_key=new_course_key)
+        self.assertEqual(rerun_state.state, CourseRerunUIStateManager.State.SUCCEEDED)
+        self.assertIsNotNone(
+            modulestore().get_course(new_course_key),
+            "Course was deleted after an auxiliary (video copy) failure",
+        )
 
 
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)


### PR DESCRIPTION
## Summary

Hardens `rerun_course` (`cms/djangoapps/contentstore/tasks.py`) so it never deletes a destination course that has already been fully cloned and marked `succeeded`, and makes the auxiliary post-succeeded steps (video copy, RestrictedCourse/CountryAccessRule clone, organization linking) individually non-fatal.

**Motivation (EDLYPRODUCT-8393):** a client reran a course with an org change. The rerun completed, the course was confirmed usable (a Course Team member was successfully added) -- then it silently disappeared and Studio Home showed "Configuration error". The only code path that deletes a rerun's destination course is the catch-all exception handler in `rerun_course`, so something in the post-`succeeded()` tail of that function (video copy / RestrictedCourse clone / org linking / event dispatch) must have raised.

**We have not identified the exact operation that threw**, and this PR does not claim to. QA could not reproduce the deletion/"Configuration error" on staging (only a transient, unrelated "Not found" on reload for a larger course, which cleared itself). Given that, the fix is deliberately defensive: it protects the course regardless of which post-succeeded step fails, rather than patching one specific suspected cause.

This is stock upstream `edx-platform` behavior (confirmed identical on `openedx/edx-platform` master) with no existing upstream fix for this bug. (Note: PR/issue #38840/#38826 upstream is a *different* rerun bug, about the `authz.enable_course_authoring` flag failing before any course exists -- not related.) Edly should consider upstreaming this hardening.

## What changed

- Added a `rerun_succeeded` guard, set immediately after `CourseRerunState.objects.succeeded(...)` is called. The catch-all `except Exception` handler now only calls `modulestore().delete_course(...)` when this is still `False` (i.e. the clone never completed / never got marked succeeded -- genuine partial garbage). Once the guard is `True`, a later failure is logged but the course is preserved.
- Wrapped each of the three auxiliary/best-effort post-succeeded steps -- `copy_course_videos`, the RestrictedCourse/CountryAccessRule clone, and `ensure_organization`/`add_organization_course` -- in its own try/except with a distinct diagnostic log message. A failure in one no longer prevents the others from running and no longer flips the rerun to failed or deletes the course.
- `DuplicateCourseError` handling and pre-/mid-clone failure cleanup (delete the partial course, mark failed) are unchanged.

## Behavior change to be aware of

Because the course is no longer deleted after a post-succeeded auxiliary failure, **re-running with the exact same destination org+number+run a second time will now hit `DuplicateCourseError`** (reported as `"duplicate course"`) instead of silently proceeding against a course that no longer exists. This is the correct/intended outcome -- the first course is real and still there -- but it's a visible behavior change from today, where a failed auxiliary step would previously vanish the course and let a retry recreate it from scratch under the same key.

## Tests

- `cms/djangoapps/contentstore/tests/test_clone_course.py`:
  - `test_rerun_course_auxiliary_step_failure_does_not_delete_course` -- forces `add_organization_course` to raise; asserts the task returns `"succeeded"`, `CourseRerunState` is `SUCCEEDED`, and the course is retrievable.
  - `test_rerun_course_post_succeeded_failure_preserves_course` -- forces a failure in `COURSE_RERUN_COMPLETED.send_event` (after `succeeded()`, outside the individually-wrapped steps); asserts the task reports the failure and the state is `FAILED`, but the course is **not** deleted.
  - Pre-existing `test_rerun_course` (failure *during* `clone_course` -> course deleted, state `FAILED`) is unchanged and still covers the genuine-partial-clone cleanup path.
- `cms/djangoapps/contentstore/tests/test_tasks.py`: `test_auxiliary_step_failure_does_not_delete_course` -- focused unit test forcing `copy_course_videos` to raise, same assertions.

## Local verification caveat

This local Tutor dev environment has a pre-existing, unrelated issue: any test that invokes a `@shared_task` (confirmed on both `rerun_course` and the unrelated `export_olx` task, and reproducible on unmodified `develop-ulmo`) currently hits `InvalidCacheBackendError: The connection 'general' doesn't exist` from Django's cache framework during/after task execution. This is independent of this change (verified on the pre-rebase baseline too) and blocks a fully green local `pytest` run for these suites in this container specifically. Across all runs, **zero `AssertionError`s** were raised -- only this cache error -- and captured logs confirm the new guard/logging fires exactly as designed (e.g. `"...already succeeded before this error was raised; preserving the course instead of deleting it."`). CI is the real gate for this PR; recommend treating a green CI run here as authoritative over the local repro.

## Out-of-scope follow-up observed

While investigating, noticed `handle_reindex_on_signal` in `openedx/core/djangoapps/content/search/handlers.py` (the receiver for `COURSE_RERUN_COMPLETED`/`COURSE_IMPORT_COMPLETED`) is missing the `@only_if_meilisearch_enabled` guard that every sibling handler in that file has, so it will raise if Meilisearch is disabled/unreachable when a rerun completes. This fires synchronously off the same `COURSE_RERUN_COMPLETED.send_event()` call inside `rerun_course`, so a Meilisearch hiccup there would land in exactly the failure window this PR now protects -- plausibly consistent with QA's observation that a *larger* course showed transient issues, though this is speculative and not confirmed. Filing separately rather than expanding this PR's scope.