### PR TITLE
feat: add verification QR code to certificates (EDLYPRODUCT-8389)

### DIFF
--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -211,6 +211,33 @@ class CommonCertificatesTestCase(ModuleStoreTestCase):
         )
         template.save()
 
+    def _create_custom_template_with_qr_code(self, org_id=None, mode=None, course_key=None, language=None):
+        """
+        Creates a custom certificate template entry in DB that renders a verification QR code,
+        mirroring how client templates (e.g. Oryx) embed it.
+        """
+        template_html = u"""
+            <%namespace name='static' file='static_content.html'/>
+            <html>
+            <body>
+                % if certificate_qr_code:
+                <img class="cert-qr" src="${certificate_qr_code | h}" alt="verify" />
+                % endif
+                <p>verify at <a href="${share_url | h}">${share_url | h}</a></p>
+            </body>
+            </html>
+        """
+        template = CertificateTemplate(
+            name='custom template with qr code',
+            template=template_html,
+            organization_id=org_id,
+            course_key=course_key,
+            mode=mode,
+            is_active=True,
+            language=language
+        )
+        template.save()
+
     def _create_custom_template_with_hours_of_effort(self, org_id=None, mode=None, course_key=None, language=None):
         """
         Creates a custom certificate template entry in DB that includes hours of effort.
@@ -1125,6 +1152,71 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, u'mode: {}'.format(mode))
             self.assertContains(response, 'course name: test_template_1_course')
+
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    def test_certificate_custom_template_with_qr_code(self, mock_get_course_run_details):
+        """
+        Tests that a custom template can render a verification QR code and that the QR code
+        encodes the same certificate URL that is printed next to it.
+        """
+        mock_get_course_run_details.return_value = self.mock_course_run_details
+        self._add_course_certificates(count=1, signatory_count=2)
+        self._create_custom_template_with_qr_code(org_id=None, mode='honor')
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=six.text_type(self.course.id),
+            uuid=self.cert.verify_uuid
+        )
+
+        with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
+            mock_get_org_id.return_value = None
+            response = self.client.get(test_url)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode('utf-8')
+
+        # The QR code renders as an inline SVG data URI, so the certificate stays self-contained
+        # in print and PDF output (no external request, no JavaScript).
+        self.assertIn('class="cert-qr" src="data:image/svg+xml', content)
+        # The printed verification link points at this certificate's own page.
+        self.assertIn(self.cert.verify_uuid, content)
+        # A data URI carrying raw markup characters would break out of the src attribute.
+        qr_data_uri = content.split('class="cert-qr" src="')[1].split('"')[0]
+        for unsafe_character in ['<', '>', '&']:
+            self.assertNotIn(unsafe_character, qr_data_uri)
+
+    @override_settings(FEATURES=FEATURES_WITH_CUSTOM_CERTS_ENABLED)
+    @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')
+    def test_certificate_qr_code_differs_per_certificate(self, mock_get_course_run_details):
+        """
+        Tests that the QR code is generated per certificate rather than being a shared image.
+
+        This is the defect the feature replaces: the previous template hardcoded a single
+        static QR asset for every learner.
+        """
+        mock_get_course_run_details.return_value = self.mock_course_run_details
+        self._add_course_certificates(count=1, signatory_count=2)
+        self._create_custom_template_with_qr_code(org_id=None, mode='honor')
+
+        qr_data_uris = []
+        for verify_uuid in [uuid4().hex, uuid4().hex]:
+            self.cert.verify_uuid = verify_uuid
+            self.cert.save()
+            test_url = get_certificate_url(
+                user_id=self.user.id,
+                course_id=six.text_type(self.course.id),
+                uuid=verify_uuid
+            )
+            with patch('lms.djangoapps.certificates.api.get_course_organization_id') as mock_get_org_id:
+                mock_get_org_id.return_value = None
+                response = self.client.get(test_url)
+
+            self.assertEqual(response.status_code, 200)
+            content = response.content.decode('utf-8')
+            qr_data_uris.append(content.split('class="cert-qr" src="')[1].split('"')[0])
+
+        self.assertNotEqual(qr_data_uris[0], qr_data_uris[1])
 
     ## Templates With Language tests
     #1

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -48,6 +48,7 @@ from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.lib.courses import course_image_url
 from openedx.features.edly.utils import (
+    get_certificate_qr_code_data_uri,
     get_current_site_invalid_certificate_context,
     get_logo_from_current_site_configurations
 )
@@ -613,6 +614,10 @@ def render_html_view(request, course_id, certificate=None):
 
         # Append social sharing info
         _update_social_context(request, context, course, user, user_certificate, platform_name)
+
+        # Append a QR code pointing at this certificate's verification page. `share_url` is set
+        # by _update_social_context above and is already absolute and tenant-aware.
+        context['certificate_qr_code'] = get_certificate_qr_code_data_uri(context.get('share_url'))
 
         # Append/Override the existing view context values with certificate specific values
         _update_certificate_context(context, course, user_certificate, platform_name)

--- a/openedx/features/edly/tests/test_utils.py
+++ b/openedx/features/edly/tests/test_utils.py
@@ -47,6 +47,7 @@ from openedx.features.edly.utils import (
     user_belongs_to_edly_sub_organization,
     user_can_login_on_requested_edly_organization,
     filter_courses_based_on_org,
+    get_certificate_qr_code_data_uri,
     get_current_site_invalid_certificate_context,
 )
 from common.djangoapps.util.password_policy_validators import SPECIAL_CHARACTERS
@@ -659,3 +660,39 @@ class UtilsTests(SharedModuleStoreTestCase):
     def test_min_length_validation(self):
         with self.assertRaises(ValueError):
             generate_password(length=7)
+
+    def test_get_certificate_qr_code_data_uri(self):
+        """
+        Test that a QR code data URI is generated and is safe to embed in an HTML attribute.
+        """
+        verification_url = 'https://example.edly.io/certificates/{uuid}'.format(uuid='a' * 32)
+        data_uri = get_certificate_qr_code_data_uri(verification_url)
+
+        self.assertTrue(data_uri.startswith('data:image/svg+xml'))
+        # Certificate templates embed this directly as an <img> src, so it must not carry
+        # characters that would terminate the attribute or open a tag.
+        for unsafe_character in ['<', '>', '"', "'", '&']:
+            self.assertNotIn(unsafe_character, data_uri)
+
+    def test_get_certificate_qr_code_data_uri_is_unique_per_certificate(self):
+        """
+        Test that two different verification URLs do not produce the same QR code.
+        """
+        first = get_certificate_qr_code_data_uri('https://example.edly.io/certificates/{}'.format('a' * 32))
+        second = get_certificate_qr_code_data_uri('https://example.edly.io/certificates/{}'.format('b' * 32))
+
+        self.assertNotEqual(first, second)
+
+    @ddt.data(None, '')
+    def test_get_certificate_qr_code_data_uri_without_url(self, verification_url):
+        """
+        Test that a missing verification URL yields an empty string instead of raising.
+        """
+        self.assertEqual(get_certificate_qr_code_data_uri(verification_url), '')
+
+    def test_get_certificate_qr_code_data_uri_survives_encoding_failure(self):
+        """
+        Test that a QR code failure never propagates out to the certificate page.
+        """
+        with mock.patch('openedx.features.edly.utils.segno.make', side_effect=ValueError('boom')):
+            self.assertEqual(get_certificate_qr_code_data_uri('https://example.edly.io/certificates/x'), '')

--- a/openedx/features/edly/utils.py
+++ b/openedx/features/edly/utils.py
@@ -11,6 +11,7 @@ import string
 from urllib.parse import urljoin, urlparse
 
 import jwt
+import segno
 import waffle
 from cryptography.fernet import Fernet
 from django.conf import settings
@@ -554,6 +555,25 @@ def is_course_org_same_as_site_org(site, course_id):
 
     LOGGER.info('Course organization does not match site organization')
     return False
+
+
+def get_certificate_qr_code_data_uri(verification_url, scale=10, border=4):
+    """
+    Return an SVG data URI of a QR code encoding a certificate's verification URL.
+
+    Certificate templates embed the result directly as an <img> src, so a failure
+    here must never break the certificate page itself. Returns an empty string
+    when there is nothing to encode or encoding fails, letting the template fall
+    back to rendering no QR code at all.
+    """
+    if not verification_url:
+        return ''
+
+    try:
+        return segno.make(verification_url, error='m').svg_data_uri(scale=scale, border=border)
+    except Exception:  # pylint: disable=broad-except
+        LOGGER.exception('Unable to build certificate verification QR code for "%s"', verification_url)
+        return ''
 
 
 def send_certificate_generation_email(msg, user, site):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -101,6 +101,10 @@ path<13.2.0
 # pillow 8.0.0 drops support for Python 3.5
 pillow<8.0.0
 
+# segno 1.6.0 requires importlib-metadata>=3.6.0 on Python <3.10, which conflicts
+# with the importlib-metadata==1.7.0 pin above. 1.5.x has zero dependencies.
+segno<1.6.0
+
 # ARCHBOM-1141: pip-tools upgrade requires pip upgrade
 pip-tools<5.0.0
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -143,6 +143,7 @@ random2
 rules                               # Django extension for rules-based authorization checks
 simplejson
 sailthru-client                     # For Sailthru integration
+segno                               # Pure-Python QR code generator; used for certificate verification QR codes
 Shapely                             # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
 social-auth-app-django

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -212,6 +212,7 @@ rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
 scipy==1.4.1              # via -c requirements/edx/../constraints.txt, chem, openedx-calc
+segno==1.5.2              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.in
 simplejson==3.17.2        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -263,6 +263,7 @@ rules==2.2                # via -r requirements/edx/testing.txt, edx-enterprise,
 s3transfer==0.1.13        # via -r requirements/edx/testing.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/testing.txt, edx-ace
 scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc
+segno==1.5.2              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 selenium==3.141.0         # via -r requirements/edx/testing.txt, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -252,6 +252,7 @@ rules==2.2                # via -r requirements/edx/base.txt, edx-enterprise, ed
 s3transfer==0.1.13        # via -r requirements/edx/base.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.txt, edx-ace
 scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc
+segno==1.5.2              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 selenium==3.141.0         # via -r requirements/edx/testing.in, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt


### PR DESCRIPTION
## What

Certificates now render a QR code unique to each certificate, encoding that certificate's own verification page on the LMS (`{tenant}/certificates/<verify_uuid>`).

Ticket: EDLYPRODUCT-8389 (parent EDLYPRODUCT-8386, Oryx). Covers requirement 1 only — the `OIEC-CICTL-U#-YYYY-XXXXX` issue-number format is requirement 2 and is tracked separately (EDLYPRODUCT-8450).

## Why the LMS and not the credentials service

The credentials service can't serve this. `RenderCredential.get_context_data` raises `Http404` for anything that isn't a `ProgramCertificate`, so `/credentials/<uuid>/` doesn't render course/unit certificates at all on Koa. Its `UserCredential.uuid` is also a different value from the `verify_uuid` printed on the certificate, so the LMS would need an authenticated credentials API call on every certificate render just to resolve it.

The LMS certificate page already shows holder name, course and issue date, and already returns the invalid-certificate view once a certificate is revoked — which satisfies the ticket's "live status (valid or revoked)" requirement with no new work.

## Two defects this fixes

- **The QR was a static placeholder.** The Oryx template hardcoded a single uploaded `qr.png` asset, so every learner's certificate carried an identical QR code.
- **The printed verify URL was broken.** It used `certificate_verify_url`, assembled from `certificate_verify_url_prefix`/`_suffix` — two keys that **nothing in edx-platform ever populates** (no code, no migration, not in the seed data). It rendered as the literal string `None<uuid>None` inside a dead `<a href="#">`.

## Changes

| File | Change |
|---|---|
| `openedx/features/edly/utils.py` | New `get_certificate_qr_code_data_uri()` returning an inline SVG data URI |
| `lms/djangoapps/certificates/views/webview.py` | One line adding `certificate_qr_code` to the certificate render context |
| `requirements/{base.in,base.txt,development.txt,testing.txt}` | Add `segno`, pinned `1.5.2` |
| `requirements/constraints.txt` | `segno<1.6.0` with the reason recorded |
| `openedx/features/edly/tests/test_utils.py` | 5 unit tests |
| `lms/djangoapps/certificates/tests/test_webview_views.py` | 2 integration tests + a QR template fixture |

Reuses the existing absolute, tenant-aware `share_url` from `_update_social_context` (already used by the social-share buttons), so no new setting or `SiteConfiguration` key was needed. Placement before `_update_certificate_context` also keeps the key overridable per course via `cert_html_view_overrides`.

The helper returns an empty string on any failure, so a QR problem can never break the certificate page itself.

### Why server-side, and why segno 1.5.2

Certificates are printed and converted to PDF, so the image has to exist without a browser executing scripts. An inline SVG data URI needs no external request, no JS, and stays sharp at any print resolution.

Both obvious alternatives break our pinned dependency set:

- `segno` ≥1.6.0 requires `importlib-metadata>=3.6.0`; we pin `importlib-metadata==1.7.0`.
- `qrcode` requires Python ≥3.9 (we're on 3.8), and its `[pil]` extra needs `pillow>=9.1.0` against our `pillow<8.0.0` constraint.

`segno==1.5.2` has zero dependencies and supports Python 3.8. The `segno<1.6.0` constraint stops a future `make upgrade` silently pulling 1.6.x.

## Testing

All pass against the Koa LMS:

- **5 unit tests** — data URI generation, uniqueness per certificate, safety of the value inside an HTML attribute, empty/missing URL handling, and graceful degradation when encoding fails.
- **2 integration tests** — render a real `CertificateTemplate` through `render_html_view` and assert the QR data URI reaches the HTML alongside the matching verification link, and that two different certificates produce **different** QR codes (the static-placeholder regression).
- The **8 pre-existing `custom_template` tests still pass**, confirming no regression in the template render path.

Also verified independently that the generated QR decodes back to the exact certificate URL, including after downscaling to print size.

Note: 6 unrelated tests in these two files fail locally; they were confirmed to fail identically at `develop-koa` without this change, so they are pre-existing.

## Deploying

Two things, or the QR is silently absent:

1. **The LMS image must be rebuilt** — this adds a dependency, so a code-only deploy is not enough.
2. **The Oryx certificate template must be updated in Django admin** (`/admin/certificates/certificatetemplate/`) on each environment. It lives in the database, not this repo, so no migration carries it. The QR block becomes:

```mako
% if certificate_qr_code:
<div class="img-holder">
  <img width="100" src="${certificate_qr_code | h}" alt="${_('QR code to verify this certificate')}" />
</div>
% endif
<p>${_('Verify this certificate at')}</p>
<p><a href="${share_url | h}">${share_url | h}</a></p>
```

The width goes 60px → 100px: at 60px the printed modules were ~0.35mm, below the ~0.4mm phone cameras reliably handle; at 100px with a standard quiet zone they're ~0.59mm.

This code change is inert until a template references `${certificate_qr_code}`, so it can ship ahead of the admin edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)