### PR TITLE
feat: per-site login field placeholders (EDLYPRODUCT-8457)

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import get_language, ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 from ratelimit.decorators import ratelimit
@@ -77,6 +77,37 @@ def _apply_third_party_auth_overrides(request, form_desc):
                 )
 
 
+def _get_custom_login_placeholders():
+    """
+    Return the login field placeholders configured for the current site, or {}.
+
+    Driven by `CUSTOM_LOGIN_PAGE` in SiteConfiguration.site_values, which backs the
+    custom logistration layout in edly-edx-themes. Returns {} unless the key is
+    present and `enabled`, so every other tenant is unaffected.
+
+    `by_language` overrides are resolved here with the same fallback chain the
+    theme applies to its hero/card copy — the full language code first, then its
+    base code (e.g. `ar-sa` then `ar`). Without this, a translated site would show
+    English placeholders beside translated labels, and the two repositories would
+    resolve the same config dict under different rules.
+    """
+    custom_login_page = configuration_helpers.get_dict('CUSTOM_LOGIN_PAGE', {}) or {}
+    if not custom_login_page.get('enabled'):
+        return {}
+
+    placeholders = dict(custom_login_page.get('placeholders') or {})
+
+    by_language = custom_login_page.get('by_language') or {}
+    language = (get_language() or '').lower()
+    for code in [code for code in (language, language.split('-')[0]) if code]:
+        overrides = by_language.get(code)
+        if overrides:
+            placeholders.update(overrides.get('placeholders') or {})
+            break
+
+    return placeholders
+
+
 def get_login_session_form(request):
     """Return a description of the login form.
 
@@ -98,10 +129,7 @@ def get_login_session_form(request):
     # (CUSTOM_LOGIN_PAGE in SiteConfiguration.site_values). Sites without that key
     # get an empty string, and form_field.underscore omits the attribute entirely,
     # so every other tenant's form is unchanged.
-    custom_login_page = configuration_helpers.get_dict('CUSTOM_LOGIN_PAGE', {}) or {}
-    field_placeholders = {}
-    if custom_login_page.get('enabled'):
-        field_placeholders = custom_login_page.get('placeholders') or {}
+    field_placeholders = _get_custom_login_placeholders()
 
     # Translators: This label appears above a field on the login form
     # meant to hold the user's email address.

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -94,6 +94,15 @@ def get_login_session_form(request):
     form_desc = FormDescription("post", reverse("user_api_login_session"))
     _apply_third_party_auth_overrides(request, form_desc)
 
+    # Optional per-site field placeholders, used by the custom logistration layout
+    # (CUSTOM_LOGIN_PAGE in SiteConfiguration.site_values). Sites without that key
+    # get an empty string, and form_field.underscore omits the attribute entirely,
+    # so every other tenant's form is unchanged.
+    custom_login_page = configuration_helpers.get_dict('CUSTOM_LOGIN_PAGE', {}) or {}
+    field_placeholders = {}
+    if custom_login_page.get('enabled'):
+        field_placeholders = custom_login_page.get('placeholders') or {}
+
     # Translators: This label appears above a field on the login form
     # meant to hold the user's email address.
     email_label = _("Email")
@@ -109,6 +118,7 @@ def get_login_session_form(request):
         field_type="email",
         label=email_label,
         instructions=email_instructions,
+        placeholder=field_placeholders.get('email', u''),
         restrictions={
             "min_length": accounts.EMAIL_MIN_LENGTH,
             "max_length": accounts.EMAIL_MAX_LENGTH,
@@ -123,6 +133,7 @@ def get_login_session_form(request):
         "password",
         label=password_label,
         field_type="password",
+        placeholder=field_placeholders.get('password', u''),
         restrictions={'max_length': DEFAULT_MAX_PASSWORD_LENGTH}
     )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -18,6 +18,7 @@ from django.http import HttpResponse
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
+from django.utils import translation
 from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import patch
 from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
@@ -36,6 +37,11 @@ from openedx.core.djangoapps.user_authn.views.login import (
 )
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.djangoapps.site_configuration.tests.test_util import (
+    with_site_configuration,
+    with_site_configuration_context
+)
+from openedx.core.djangoapps.user_authn.views.login_form import _get_custom_login_placeholders
 from openedx.core.lib.api.test_utils import ApiTestCase
 from common.djangoapps.util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
 
@@ -866,6 +872,82 @@ class LoginSessionViewTest(ApiTestCase):
                 "loginIssueSupportLink": "https://support.example.com/login-issue-help.html",
             },
         ])
+
+    def _get_field_placeholders(self):
+        """Return {field name: placeholder} from the login form description."""
+        response = self.client.get(self.url, content_type="application/json")
+        self.assertHttpOK(response)
+        form_desc = json.loads(response.content.decode('utf-8'))
+        return {field["name"]: field["placeholder"] for field in form_desc["fields"]}
+
+    @with_site_configuration(configuration={
+        'CUSTOM_LOGIN_PAGE': {
+            'enabled': True,
+            'placeholders': {'email': 'you@school.edu', 'password': '********'},
+        }
+    })
+    def test_login_form_custom_placeholders(self):
+        """A site with CUSTOM_LOGIN_PAGE placeholders gets them on both fields."""
+        self.assertEqual(
+            self._get_field_placeholders(),
+            {"email": "you@school.edu", "password": "********"},
+        )
+
+    @with_site_configuration(configuration={
+        'CUSTOM_LOGIN_PAGE': {
+            'enabled': False,
+            'placeholders': {'email': 'you@school.edu', 'password': '********'},
+        }
+    })
+    def test_login_form_custom_placeholders_respects_enabled_gate(self):
+        """`enabled: False` must suppress placeholders even when they are configured.
+
+        This gate is the whole isolation story for the feature, so it is asserted
+        directly rather than inferred from the unconfigured case.
+        """
+        self.assertEqual(self._get_field_placeholders(), {"email": "", "password": ""})
+
+    def test_custom_placeholders_by_language(self):
+        """`by_language` overrides resolve per language, falling back to the base code.
+
+        Mirrors the resolution the theme applies to its hero/card copy: the full
+        language code first, then its base code. Keys the override does not mention
+        keep the top-level value.
+
+        Asserted against the resolver rather than through the view: a request would
+        have its active language re-negotiated by LocaleMiddleware/DarkLangMiddleware
+        from the request itself, discarding `translation.override` and only ever
+        exercising released languages.
+        """
+        configuration = {
+            'CUSTOM_LOGIN_PAGE': {
+                'enabled': True,
+                'placeholders': {'email': 'you@school.edu', 'password': '********'},
+                'by_language': {'ar': {'placeholders': {'email': 'you@school.edu.ar'}}},
+            }
+        }
+        with with_site_configuration_context(configuration=configuration):
+            # Full code `ar-sa` falls back to the `ar` override; `password` is not
+            # mentioned there, so it keeps the top-level value.
+            with translation.override('ar-sa'):
+                self.assertEqual(
+                    _get_custom_login_placeholders(),
+                    {"email": "you@school.edu.ar", "password": "********"},
+                )
+
+            # Exact code match.
+            with translation.override('ar'):
+                self.assertEqual(
+                    _get_custom_login_placeholders(),
+                    {"email": "you@school.edu.ar", "password": "********"},
+                )
+
+            # An unrelated language falls through to the top-level placeholders.
+            with translation.override('fr'):
+                self.assertEqual(
+                    _get_custom_login_placeholders(),
+                    {"email": "you@school.edu", "password": "********"},
+                )
 
     @ddt.data(True, False)
     @patch('openedx.core.djangoapps.user_authn.views.login.segment')


### PR DESCRIPTION
**Description:** Allow a site to supply email/password placeholders for the login form, for the ORYX custom sign-in layout.

**Ticket:** EDLYPRODUCT-8457 — [koa] [Oryx] Update Sign in Page UI in accordance to the custom design

**Companion PR:** edly-io/edly-edx-themes#445 — the layout itself. This PR only supplies the placeholders that layout needs.

## What changed

One block and two keyword arguments in `get_login_session_form()` (`openedx/core/djangoapps/user_authn/views/login_form.py`):

```python
custom_login_page = configuration_helpers.get_dict('CUSTOM_LOGIN_PAGE', {}) or {}
field_placeholders = {}
if custom_login_page.get('enabled'):
    field_placeholders = custom_login_page.get('placeholders') or {}
```

…then `placeholder=field_placeholders.get('email', u'')` and `placeholder=field_placeholders.get('password', u'')` on the two `add_field()` calls. 11 added lines, nothing removed.

## Why this shape

`FormDescription.add_field()` already accepts `placeholder` (`openedx/core/djangoapps/user_api/helpers.py`) and `form_field.underscore` already renders it — the login form description simply never set one. So this needs no template change and no fork of the shared `form_field.underscore`.

## Why it is safe for other tenants

Sites without the `CUSTOM_LOGIN_PAGE` key, or with `enabled` falsy, get `u''`. `form_field.underscore` guards the attribute with `<% if ( placeholder ) { %>`, so the rendered markup for every other tenant is unchanged. No new Django setting, no migration, and no change to validation or submission behaviour.

## Testing

Verified on a Koa devstack:

- With `CUSTOM_LOGIN_PAGE.placeholders` set, the login fields render `placeholder="you@school.edu"` and `placeholder="••••••••"`.
- With the key removed, both attributes are absent from the DOM and the form matches the stock output.
- Sign-in and validation unaffected — a wrong password still returns "Email or password is incorrect."

## Note

Labels are retained, so the placeholders are additive rather than replacing labels. This does not introduce the placeholder-as-label accessibility problem.
